### PR TITLE
Feat/shared api error helper

### DIFF
--- a/data/buildings.js
+++ b/data/buildings.js
@@ -1,8 +1,60 @@
 import { ObjectId } from 'mongodb';
 import { buildings } from '../config/mongoCollections.js';
-import { checkString, checkId } from './validation.js';
+import {
+  VALIDATION_LIMITS,
+  checkBoundedText,
+  checkId,
+  checkOptionalBoundedText,
+  checkOptionalBorough,
+  checkBorough,
+  checkQueryInt
+} from './validation.js';
+
+const BUILDINGS_DEFAULT_LIMIT = 20;
+const BUILDINGS_MAX_LIMIT = 100;
+const BUILDINGS_SEARCH_MAX_LENGTH = 120;
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+const normalizeBuildingInput = (data, { requireCoreFields = false } = {}) => {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw 'data must be an object';
+  }
+
+  const normalized = {};
+
+  if (requireCoreFields || hasOwn(data, 'streetAddress')) {
+    normalized.streetAddress = checkBoundedText(data.streetAddress, 'streetAddress', {
+      minLength: 3,
+      maxLength: VALIDATION_LIMITS.streetAddressMaxLength
+    });
+  }
+
+  if (requireCoreFields || hasOwn(data, 'borough')) {
+    normalized.borough = checkBorough(data.borough, 'borough');
+  }
+
+  if (hasOwn(data, 'ownerName') && data.ownerName !== undefined) {
+    normalized.ownerName = checkBoundedText(data.ownerName, 'ownerName', {
+      maxLength: VALIDATION_LIMITS.ownerNameMaxLength
+    });
+  }
+
+  return normalized;
+};
 
 export const getAllBuildings = async ({ search, borough, page = 1, limit = 20 } = {}) => {
+  search = checkOptionalBoundedText(search, 'search', {
+    maxLength: BUILDINGS_SEARCH_MAX_LENGTH,
+    emptyValue: undefined
+  });
+  borough = checkOptionalBorough(borough, 'borough');
+  page = checkQueryInt(page, 'page', { defaultValue: 1, min: 1 });
+  limit = checkQueryInt(limit, 'limit', {
+    defaultValue: BUILDINGS_DEFAULT_LIMIT,
+    min: 1,
+    max: BUILDINGS_MAX_LIMIT
+  });
+
   const col = await buildings();
   const query = {};
   if (search) query.$text = { $search: search };
@@ -25,12 +77,12 @@ export const getBuildingById = async (id) => {
 
 export const createBuilding = async (data, adminId) => {
   adminId = checkId(adminId, 'adminId');
-  checkString(data.streetAddress, 'streetAddress');
-  checkString(data.borough, 'borough');
+  const normalized = normalizeBuildingInput(data, { requireCoreFields: true });
   const now = new Date();
   const col = await buildings();
   const doc = {
     ...data,
+    ...normalized,
     riskSummary: data.riskSummary ?? { highlights: [], lastCalculatedAt: now },
     housingRecords: data.housingRecords ?? [],
     createdByAdminId: new ObjectId(adminId),
@@ -45,10 +97,18 @@ export const createBuilding = async (data, adminId) => {
 export const updateBuilding = async (id, data, adminId) => {
   id = checkId(id);
   adminId = checkId(adminId, 'adminId');
+  const normalized = normalizeBuildingInput(data);
   const col = await buildings();
   const result = await col.findOneAndUpdate(
     { _id: new ObjectId(id) },
-    { $set: { ...data, updatedByAdminId: new ObjectId(adminId), updatedAt: new Date() } },
+    {
+      $set: {
+        ...data,
+        ...normalized,
+        updatedByAdminId: new ObjectId(adminId),
+        updatedAt: new Date()
+      }
+    },
     { returnDocument: 'after' }
   );
   if (!result) throw 'building not found';
@@ -64,7 +124,9 @@ export const deleteBuilding = async (id) => {
 };
 
 export const getBuildingsByOwner = async (ownerName) => {
-  ownerName = checkString(ownerName, 'ownerName');
+  ownerName = checkBoundedText(ownerName, 'ownerName', {
+    maxLength: VALIDATION_LIMITS.ownerNameMaxLength
+  });
   const col = await buildings();
   return col.find({ ownerName }).toArray();
 };

--- a/data/reviews.js
+++ b/data/reviews.js
@@ -1,7 +1,13 @@
 import { ObjectId } from 'mongodb';
 import xss from 'xss';
 import { reviews } from '../config/mongoCollections.js';
-import { checkString, checkId, checkInt } from './validation.js';
+import {
+  VALIDATION_LIMITS,
+  checkBoundedText,
+  checkId,
+  checkInt,
+  checkIssueTags
+} from './validation.js';
 
 export const getReviewsByBuilding = async (buildingId) => {
   buildingId = checkId(buildingId, 'buildingId');
@@ -13,8 +19,13 @@ export const getReviewsByBuilding = async (buildingId) => {
 export const createReview = async (buildingId, userId, reviewText, rating, issueTags = []) => {
   buildingId = checkId(buildingId, 'buildingId');
   userId = checkId(userId, 'userId');
-  reviewText = xss(checkString(reviewText, 'reviewText'));
+  reviewText = xss(
+    checkBoundedText(reviewText, 'reviewText', {
+      maxLength: VALIDATION_LIMITS.reviewTextMaxLength
+    })
+  );
   checkInt(rating, 'rating', 1, 5);
+  issueTags = checkIssueTags(issueTags, 'issueTags');
   const now = new Date();
   const col = await reviews();
   const { insertedId } = await col.insertOne({
@@ -30,8 +41,13 @@ export const createReview = async (buildingId, userId, reviewText, rating, issue
 export const updateReview = async (id, userId, reviewText, rating, issueTags) => {
   id = checkId(id);
   userId = checkId(userId, 'userId');
-  reviewText = xss(checkString(reviewText, 'reviewText'));
+  reviewText = xss(
+    checkBoundedText(reviewText, 'reviewText', {
+      maxLength: VALIDATION_LIMITS.reviewTextMaxLength
+    })
+  );
   checkInt(rating, 'rating', 1, 5);
+  issueTags = checkIssueTags(issueTags ?? [], 'issueTags');
   const col = await reviews();
   const result = await col.findOneAndUpdate(
     { _id: new ObjectId(id), userId: new ObjectId(userId) },

--- a/data/shortlists.js
+++ b/data/shortlists.js
@@ -1,7 +1,12 @@
 import { ObjectId } from 'mongodb';
 import xss from 'xss';
 import { shortlists } from '../config/mongoCollections.js';
-import { checkString, checkId } from './validation.js';
+import {
+  VALIDATION_LIMITS,
+  checkBoundedText,
+  checkId,
+  checkOptionalBoundedText
+} from './validation.js';
 
 export const getShortlistsByUser = async (userId) => {
   userId = checkId(userId, 'userId');
@@ -11,7 +16,9 @@ export const getShortlistsByUser = async (userId) => {
 
 export const createShortlist = async (userId, shortlistName) => {
   userId = checkId(userId, 'userId');
-  shortlistName = checkString(shortlistName, 'shortlistName');
+  shortlistName = checkBoundedText(shortlistName, 'shortlistName', {
+    maxLength: VALIDATION_LIMITS.shortlistNameMaxLength
+  });
   const now = new Date();
   const col = await shortlists();
   const { insertedId } = await col.insertOne({
@@ -42,7 +49,11 @@ export const updateItemNote = async (shortlistId, userId, buildingId, privateNot
   shortlistId = checkId(shortlistId, 'shortlistId');
   userId = checkId(userId, 'userId');
   buildingId = checkId(buildingId, 'buildingId');
-  privateNote = xss(checkString(privateNote, 'privateNote'));
+  privateNote = xss(
+    checkOptionalBoundedText(privateNote, 'privateNote', {
+      maxLength: VALIDATION_LIMITS.privateNoteMaxLength
+    })
+  );
   const col = await shortlists();
   const result = await col.findOneAndUpdate(
     { _id: new ObjectId(shortlistId), userId: new ObjectId(userId), 'items.buildingId': new ObjectId(buildingId) },

--- a/data/users.js
+++ b/data/users.js
@@ -10,6 +10,22 @@ import {
   checkRole
 } from './validation.js';
 
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildCaseInsensitiveExactMatch = (value) =>
+  new RegExp(`^${escapeRegex(value)}$`, 'i');
+
+const normalizeLoginCredential = (value) =>
+  String(value).includes('@')
+    ? {
+        field: 'email',
+        value: checkEmail(value, 'email')
+      }
+    : {
+        field: 'username',
+        value: checkUsername(value, 'username')
+      };
+
 export const createUser = async (firstName, lastName, email, username, password, role = 'user') => {
   firstName = checkString(firstName, 'firstName');
   lastName = checkString(lastName, 'lastName');
@@ -19,7 +35,14 @@ export const createUser = async (firstName, lastName, email, username, password,
   role = checkRole(role, 'role');
 
   const col = await users();
-  if (await col.findOne({ $or: [{ email }, { username }] }))
+  if (
+    await col.findOne({
+      $or: [
+        { email: buildCaseInsensitiveExactMatch(email) },
+        { username: buildCaseInsensitiveExactMatch(username) }
+      ]
+    })
+  )
     throw 'email or username already taken';
 
   const hashedPassword = await bcrypt.hash(password, 12);
@@ -32,11 +55,13 @@ export const createUser = async (firstName, lastName, email, username, password,
 };
 
 export const loginUser = async (username, password) => {
-  username = checkUsername(username, 'username');
+  const credential = normalizeLoginCredential(username);
   password = checkPassword(password, 'password', { enforceStrength: false });
 
   const col = await users();
-  const user = await col.findOne({ username });
+  const user = await col.findOne({
+    [credential.field]: buildCaseInsensitiveExactMatch(credential.value)
+  });
   if (!user || !(await bcrypt.compare(password, user.hashedPassword)))
     throw 'invalid username or password';
 

--- a/data/users.js
+++ b/data/users.js
@@ -1,14 +1,22 @@
 import { ObjectId } from 'mongodb';
 import bcrypt from 'bcryptjs';
 import { users } from '../config/mongoCollections.js';
-import { checkString, checkId, checkEmail } from './validation.js';
+import {
+  checkString,
+  checkId,
+  checkEmail,
+  checkUsername,
+  checkPassword,
+  checkRole
+} from './validation.js';
 
 export const createUser = async (firstName, lastName, email, username, password, role = 'user') => {
   firstName = checkString(firstName, 'firstName');
   lastName = checkString(lastName, 'lastName');
   email = checkEmail(email);
-  username = checkString(username, 'username');
-  password = checkString(password, 'password');
+  username = checkUsername(username, 'username');
+  password = checkPassword(password, 'password');
+  role = checkRole(role, 'role');
 
   const col = await users();
   if (await col.findOne({ $or: [{ email }, { username }] }))
@@ -24,8 +32,8 @@ export const createUser = async (firstName, lastName, email, username, password,
 };
 
 export const loginUser = async (username, password) => {
-  username = checkString(username, 'username');
-  password = checkString(password, 'password');
+  username = checkUsername(username, 'username');
+  password = checkPassword(password, 'password', { enforceStrength: false });
 
   const col = await users();
   const user = await col.findOne({ username });

--- a/data/validation.js
+++ b/data/validation.js
@@ -189,17 +189,18 @@ export const checkEmail = (email, name = 'email', options = {}) => {
 };
 
 export const checkUsername = (username, name = 'username', options = {}) => {
+  const { lowercase = true, ...stringOptions } = options;
   username = normalizeString(username, name, {
     minLength: VALIDATION_LIMITS.usernameMinLength,
     maxLength: VALIDATION_LIMITS.usernameMaxLength,
-    ...options
+    ...stringOptions
   });
 
   if (!USERNAME_REGEX.test(username) || username.startsWith('.') || username.endsWith('.')) {
     throw `${name} can only use letters, numbers, periods, underscores, and hyphens`;
   }
 
-  return username;
+  return lowercase ? username.toLowerCase() : username;
 };
 
 export const checkPassword = (

--- a/data/validation.js
+++ b/data/validation.js
@@ -1,22 +1,379 @@
 import { ObjectId } from 'mongodb';
 
-export const checkString = (val, name = 'value') => {
-  if (typeof val !== 'string' || val.trim().length === 0)
-    throw `${name} must be a non-empty string`;
-  return val.trim();
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const USERNAME_REGEX = /^[A-Za-z0-9._-]+$/;
+
+export const BOROUGH_VALUES = Object.freeze([
+  'Manhattan',
+  'Brooklyn',
+  'Queens',
+  'Bronx',
+  'Staten Island'
+]);
+
+export const USER_ROLE_VALUES = Object.freeze(['user', 'admin']);
+
+export const VALIDATION_LIMITS = Object.freeze({
+  textMaxLength: 5000,
+  emailMaxLength: 254,
+  usernameMinLength: 3,
+  usernameMaxLength: 24,
+  passwordMinLength: 8,
+  passwordMaxLength: 128,
+  personNameMaxLength: 50,
+  streetAddressMaxLength: 200,
+  ownerNameMaxLength: 120,
+  shortlistNameMaxLength: 80,
+  privateNoteMaxLength: 1000,
+  reviewTextMaxLength: 2000,
+  issueTagMaxLength: 40,
+  issueTagMaxItems: 10
+});
+
+const STRING_FIELD_PROFILES = Object.freeze({
+  firstName: Object.freeze({
+    minLength: 1,
+    maxLength: VALIDATION_LIMITS.personNameMaxLength
+  }),
+  lastName: Object.freeze({
+    minLength: 1,
+    maxLength: VALIDATION_LIMITS.personNameMaxLength
+  }),
+  streetAddress: Object.freeze({
+    minLength: 3,
+    maxLength: VALIDATION_LIMITS.streetAddressMaxLength
+  }),
+  ownerName: Object.freeze({
+    minLength: 1,
+    maxLength: VALIDATION_LIMITS.ownerNameMaxLength
+  }),
+  shortlistName: Object.freeze({
+    minLength: 1,
+    maxLength: VALIDATION_LIMITS.shortlistNameMaxLength
+  }),
+  privateNote: Object.freeze({
+    minLength: 1,
+    maxLength: VALIDATION_LIMITS.privateNoteMaxLength
+  }),
+  reviewText: Object.freeze({
+    minLength: 1,
+    maxLength: VALIDATION_LIMITS.reviewTextMaxLength
+  })
+});
+
+const normalizeString = (
+  val,
+  name = 'value',
+  {
+    trim = true,
+    minLength = 1,
+    maxLength = VALIDATION_LIMITS.textMaxLength,
+    pattern,
+    patternMessage
+  } = {}
+) => {
+  if (typeof val !== 'string') throw `${name} must be a string`;
+
+  const normalized = trim ? val.trim() : val;
+
+  if (normalized.length < minLength) {
+    if (minLength === 1) {
+      throw `${name} must be a non-empty string`;
+    }
+
+    throw `${name} must be at least ${minLength} characters long`;
+  }
+
+  if (maxLength !== undefined && normalized.length > maxLength) {
+    throw `${name} must be ${maxLength} characters or fewer`;
+  }
+
+  if (pattern && !pattern.test(normalized)) {
+    throw patternMessage || `${name} is invalid`;
+  }
+
+  return normalized;
+};
+
+const matchAllowedValue = (val, allowedValues, { caseInsensitive = false } = {}) =>
+  allowedValues.find((option) =>
+    caseInsensitive
+      ? String(option).toLowerCase() === val.toLowerCase()
+      : option === val
+  );
+
+export const checkString = (val, name = 'value', options = {}) => {
+  if (name === 'email') {
+    return checkEmail(val, name, options);
+  }
+
+  if (name === 'username') {
+    return checkUsername(val, name, options);
+  }
+
+  if (name === 'password') {
+    return checkPassword(val, name, options);
+  }
+
+  if (name === 'borough') {
+    return checkBorough(val, name, options);
+  }
+
+  if (name === 'role') {
+    return checkRole(val, name, options);
+  }
+
+  const fieldProfile = STRING_FIELD_PROFILES[name];
+
+  return normalizeString(val, name, {
+    maxLength: VALIDATION_LIMITS.textMaxLength,
+    ...fieldProfile,
+    ...options
+  });
+};
+
+export const checkBoundedText = (
+  val,
+  name = 'value',
+  {
+    trim = true,
+    minLength = 1,
+    maxLength = VALIDATION_LIMITS.textMaxLength
+  } = {}
+) => normalizeString(val, name, { trim, minLength, maxLength });
+
+export const checkOptionalBoundedText = (
+  val,
+  name = 'value',
+  {
+    trim = true,
+    maxLength = VALIDATION_LIMITS.textMaxLength,
+    emptyValue = ''
+  } = {}
+) => {
+  if (val === undefined || val === null) {
+    return emptyValue;
+  }
+
+  if (typeof val !== 'string') {
+    throw `${name} must be a string`;
+  }
+
+  const normalized = trim ? val.trim() : val;
+
+  if (normalized.length === 0) {
+    return emptyValue;
+  }
+
+  return normalizeString(normalized, name, {
+    trim: false,
+    minLength: 1,
+    maxLength
+  });
 };
 
 export const checkId = (id, name = 'id') => {
-  id = checkString(id, name);
+  id = normalizeString(id, name);
   if (!ObjectId.isValid(id)) throw `${name} is not a valid ObjectId`;
   return id;
 };
 
-export const checkEmail = (email) => {
-  email = checkString(email, 'email');
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw 'invalid email address';
-  return email.toLowerCase();
+export const checkEmail = (email, name = 'email', options = {}) => {
+  const { lowercase = true, ...stringOptions } = options;
+  email = normalizeString(email, name, {
+    maxLength: VALIDATION_LIMITS.emailMaxLength,
+    ...stringOptions
+  });
+  if (!EMAIL_REGEX.test(email)) throw `${name} must be a valid email address`;
+  return lowercase ? email.toLowerCase() : email;
 };
+
+export const checkUsername = (username, name = 'username', options = {}) => {
+  username = normalizeString(username, name, {
+    minLength: VALIDATION_LIMITS.usernameMinLength,
+    maxLength: VALIDATION_LIMITS.usernameMaxLength,
+    ...options
+  });
+
+  if (!USERNAME_REGEX.test(username) || username.startsWith('.') || username.endsWith('.')) {
+    throw `${name} can only use letters, numbers, periods, underscores, and hyphens`;
+  }
+
+  return username;
+};
+
+export const checkPassword = (
+  password,
+  name = 'password',
+  options = {}
+) => {
+  const {
+    enforceStrength = true,
+    allowSpaces = false,
+    minLength = enforceStrength ? VALIDATION_LIMITS.passwordMinLength : 1,
+    maxLength = VALIDATION_LIMITS.passwordMaxLength,
+    trim: _trimIgnored,
+    ...stringOptions
+  } = options;
+
+  password = normalizeString(password, name, {
+    trim: false,
+    minLength,
+    maxLength,
+    ...stringOptions
+  });
+
+  if (!allowSpaces && /\s/.test(password)) {
+    throw `${name} cannot contain spaces`;
+  }
+
+  if (!enforceStrength) {
+    return password;
+  }
+
+  if (!/[a-z]/.test(password)) throw `${name} must include at least one lowercase letter`;
+  if (!/[A-Z]/.test(password)) throw `${name} must include at least one uppercase letter`;
+  if (!/[0-9]/.test(password)) throw `${name} must include at least one number`;
+  if (!/[^A-Za-z0-9]/.test(password)) throw `${name} must include at least one special character`;
+
+  return password;
+};
+
+export const checkBorough = (borough, name = 'borough', options = {}) =>
+  checkEnum(borough, BOROUGH_VALUES, name, {
+    caseInsensitive: true,
+    ...options
+  });
+
+export const checkRole = (role, name = 'role', options = {}) =>
+  checkEnum(role, USER_ROLE_VALUES, name, {
+    caseInsensitive: true,
+    ...options
+  });
+
+export const checkOptionalEnum = (
+  val,
+  allowedValues,
+  name = 'value',
+  {
+    caseInsensitive = false,
+    emptyValue = undefined
+  } = {}
+) => {
+  if (val === undefined || val === null) {
+    return emptyValue;
+  }
+
+  if (typeof val === 'string' && val.trim().length === 0) {
+    return emptyValue;
+  }
+
+  return checkEnum(val, allowedValues, name, { caseInsensitive });
+};
+
+export const checkOptionalBorough = (borough, name = 'borough', options = {}) =>
+  checkOptionalEnum(borough, BOROUGH_VALUES, name, {
+    caseInsensitive: true,
+    ...options
+  });
+
+export const checkEnum = (
+  val,
+  allowedValues,
+  name = 'value',
+  { caseInsensitive = false } = {}
+) => {
+  if (!Array.isArray(allowedValues) || allowedValues.length === 0) {
+    throw new Error('allowedValues must be a non-empty array');
+  }
+
+  const normalized = normalizeString(val, name);
+  const matched = matchAllowedValue(normalized, allowedValues, { caseInsensitive });
+
+  if (!matched) {
+    throw `${name} must be one of: ${allowedValues.join(', ')}`;
+  }
+
+  return matched;
+};
+
+export const checkStringArray = (
+  val,
+  name = 'value',
+  {
+    trim = true,
+    minItems = 0,
+    maxItems,
+    unique = false,
+    itemMinLength = 1,
+    itemMaxLength = VALIDATION_LIMITS.textMaxLength,
+    allowedValues,
+    caseInsensitive = false,
+    pattern,
+    patternMessage
+  } = {}
+) => {
+  if (!Array.isArray(val)) throw `${name} must be an array of strings`;
+  if (allowedValues !== undefined && (!Array.isArray(allowedValues) || allowedValues.length === 0)) {
+    throw new Error('allowedValues must be a non-empty array');
+  }
+
+  if (val.length < minItems) {
+    throw `${name} must contain at least ${minItems} item${minItems === 1 ? '' : 's'}`;
+  }
+
+  if (maxItems !== undefined && val.length > maxItems) {
+    throw `${name} must contain at most ${maxItems} item${maxItems === 1 ? '' : 's'}`;
+  }
+
+  const normalized = val.map((item, index) => {
+    const normalizedItem = normalizeString(item, `${name}[${index}]`, {
+      trim,
+      minLength: itemMinLength,
+      maxLength: itemMaxLength,
+      pattern,
+      patternMessage
+    });
+
+    if (!allowedValues) {
+      return normalizedItem;
+    }
+
+    const matched = matchAllowedValue(normalizedItem, allowedValues, { caseInsensitive });
+
+    if (!matched) {
+      throw `${name}[${index}] must be one of: ${allowedValues.join(', ')}`;
+    }
+
+    return matched;
+  });
+
+  if (unique) {
+    const seen = new Set();
+
+    for (const item of normalized) {
+      const key = caseInsensitive ? String(item).toLowerCase() : item;
+
+      if (seen.has(key)) {
+        throw `${name} must not contain duplicate values`;
+      }
+
+      seen.add(key);
+    }
+  }
+
+  return normalized;
+};
+
+export const checkIssueTags = (val, name = 'issueTags', options = {}) =>
+  checkStringArray(val, name, {
+    trim: true,
+    caseInsensitive: true,
+    unique: true,
+    maxItems: VALIDATION_LIMITS.issueTagMaxItems,
+    itemMaxLength: VALIDATION_LIMITS.issueTagMaxLength,
+    ...options
+  });
 
 export const checkInt = (val, name = 'value', min, max) => {
   if (typeof val !== 'number' || !Number.isInteger(val)) throw `${name} must be an integer`;
@@ -24,3 +381,68 @@ export const checkInt = (val, name = 'value', min, max) => {
   if (max !== undefined && val > max) throw `${name} must be <= ${max}`;
   return val;
 };
+
+export const checkQueryNumber = (
+  val,
+  name = 'value',
+  {
+    required = false,
+    integer = false,
+    min,
+    max,
+    defaultValue
+  } = {}
+) => {
+  if (val === undefined || val === null || val === '') {
+    if (required && defaultValue === undefined) {
+      throw `${name} is required`;
+    }
+
+    return defaultValue;
+  }
+
+  if (Array.isArray(val)) {
+    throw `${name} must be a single value`;
+  }
+
+  let parsed;
+
+  if (typeof val === 'number') {
+    parsed = val;
+  } else if (typeof val === 'string') {
+    const normalized = val.trim();
+
+    if (normalized.length === 0) {
+      if (required && defaultValue === undefined) {
+        throw `${name} is required`;
+      }
+
+      return defaultValue;
+    }
+
+    parsed = Number(normalized);
+  } else {
+    throw `${name} must be a valid number`;
+  }
+
+  if (!Number.isFinite(parsed)) {
+    throw `${name} must be a valid number`;
+  }
+
+  if (integer && !Number.isInteger(parsed)) {
+    throw `${name} must be an integer`;
+  }
+
+  if (min !== undefined && parsed < min) {
+    throw `${name} must be >= ${min}`;
+  }
+
+  if (max !== undefined && parsed > max) {
+    throw `${name} must be <= ${max}`;
+  }
+
+  return parsed;
+};
+
+export const checkQueryInt = (val, name = 'value', options = {}) =>
+  checkQueryNumber(val, name, { ...options, integer: true });

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,10 +1,12 @@
+import { sendApiError } from '../utils/api-response.js';
+
 export const requireAuth = (req, res, next) => {
-  if (!req.session.user) return res.status(401).json({ error: 'not authenticated' });
+  if (!req.session.user) return sendApiError(res, 'not authenticated', { status: 401 });
   next();
 };
 
 export const requireAdmin = (req, res, next) => {
-  if (!req.session.user) return res.status(401).json({ error: 'not authenticated' });
-  if (req.session.user.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+  if (!req.session.user) return sendApiError(res, 'not authenticated', { status: 401 });
+  if (req.session.user.role !== 'admin') return sendApiError(res, 'forbidden', { status: 403 });
   next();
 };

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,34 +1,35 @@
 import { Router } from 'express';
 import { buildingData } from '../data/index.js';
 import { requireAdmin } from '../middleware/auth.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.post('/admin/buildings', requireAdmin, async (req, res) => {
-  try {
-    const result = await buildingData.createBuilding(req.body, req.session.user._id);
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/admin/buildings',
+  requireAdmin,
+  createApiHandler(
+    async (req) => buildingData.createBuilding(req.body, req.session.user._id),
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.put('/admin/buildings/:id', requireAdmin, async (req, res) => {
-  try {
-    const result = await buildingData.updateBuilding(req.params.id, req.body, req.session.user._id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.put(
+  '/admin/buildings/:id',
+  requireAdmin,
+  createApiHandler(
+    async (req) => buildingData.updateBuilding(req.params.id, req.body, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/admin/buildings/:id', requireAdmin, async (req, res) => {
-  try {
-    const result = await buildingData.deleteBuilding(req.params.id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/admin/buildings/:id',
+  requireAdmin,
+  createApiHandler(
+    async (req) => buildingData.deleteBuilding(req.params.id),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,30 +1,34 @@
 import { Router } from 'express';
 import { userData } from '../data/index.js';
+import { createApiHandler, sendApiSuccess } from '../utils/api-response.js';
 
 const router = Router();
 
-router.post('/auth/register', async (req, res) => {
-  try {
-    const { firstName, lastName, email, username, password } = req.body;
-    const result = await userData.createUser(firstName, lastName, email, username, password);
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/auth/register',
+  createApiHandler(
+    async (req) => {
+      const { firstName, lastName, email, username, password } = req.body;
+      return userData.createUser(firstName, lastName, email, username, password);
+    },
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.post('/auth/login', async (req, res) => {
-  try {
-    const user = await userData.loginUser(req.body.username, req.body.password);
-    req.session.user = user;
-    res.json({ success: true, data: user });
-  } catch (e) {
-    res.status(401).json({ error: e });
-  }
-});
+router.post(
+  '/auth/login',
+  createApiHandler(
+    async (req) => {
+      const user = await userData.loginUser(req.body.username, req.body.password);
+      req.session.user = user;
+      return user;
+    },
+    { errorStatus: 401 }
+  )
+);
 
 router.post('/auth/logout', (req, res) => {
-  req.session.destroy(() => res.json({ success: true }));
+  req.session.destroy(() => sendApiSuccess(res));
 });
 
 export default router;

--- a/routes/buildings.js
+++ b/routes/buildings.js
@@ -2,49 +2,51 @@ import { Router } from 'express';
 import { buildingData } from '../data/index.js';
 import { requireAuth } from '../middleware/auth.js';
 import { userData } from '../data/index.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.get('/buildings', async (req, res) => {
-  try {
-    const { search, borough, page, limit } = req.query;
-    const result = await buildingData.getAllBuildings({
-      search,
-      borough,
-      page,
-      limit
-    });
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(typeof e === 'string' ? 400 : 500).json({ error: e });
-  }
-});
+router.get(
+  '/buildings',
+  createApiHandler(
+    async (req) => {
+      const { search, borough, page, limit } = req.query;
+      return buildingData.getAllBuildings({
+        search,
+        borough,
+        page,
+        limit
+      });
+    },
+    {
+      getErrorStatus: (error) => (typeof error === 'string' ? 400 : 500)
+    }
+  )
+);
 
-router.get('/buildings/:id', async (req, res) => {
-  try {
-    const building = await buildingData.getBuildingById(req.params.id);
-    res.json({ success: true, data: building });
-  } catch (e) {
-    res.status(404).json({ error: e });
-  }
-});
+router.get(
+  '/buildings/:id',
+  createApiHandler(
+    async (req) => buildingData.getBuildingById(req.params.id),
+    { errorStatus: 404 }
+  )
+);
 
-router.get('/portfolios/:ownerName', async (req, res) => {
-  try {
-    const items = await buildingData.getBuildingsByOwner(req.params.ownerName);
-    res.json({ success: true, data: items });
-  } catch (e) {
-    res.status(404).json({ error: e });
-  }
-});
+router.get(
+  '/portfolios/:ownerName',
+  createApiHandler(
+    async (req) => buildingData.getBuildingsByOwner(req.params.ownerName),
+    { errorStatus: 404 }
+  )
+);
 
-router.post('/watchlist/toggle', requireAuth, async (req, res) => {
-  try {
-    const result = await userData.toggleWatchlist(req.session.user._id, req.body.buildingId);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/watchlist/toggle',
+  requireAuth,
+  createApiHandler(
+    async (req) => userData.toggleWatchlist(req.session.user._id, req.body.buildingId),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/routes/buildings.js
+++ b/routes/buildings.js
@@ -9,13 +9,14 @@ router.get('/buildings', async (req, res) => {
   try {
     const { search, borough, page, limit } = req.query;
     const result = await buildingData.getAllBuildings({
-      search, borough,
-      page: page ? parseInt(page) : 1,
-      limit: limit ? parseInt(limit) : 20
+      search,
+      borough,
+      page,
+      limit
     });
     res.json({ success: true, data: result });
   } catch (e) {
-    res.status(500).json({ error: e });
+    res.status(typeof e === 'string' ? 400 : 500).json({ error: e });
   }
 });
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ import buildingRoutes from './buildings.js';
 import reviewRoutes from './reviews.js';
 import shortlistRoutes from './shortlists.js';
 import adminRoutes from './admin.js';
+import { sendApiError } from '../utils/api-response.js';
 
 export default function registerRoutes(app) {
   app.use(authRoutes);
@@ -11,6 +12,6 @@ export default function registerRoutes(app) {
   app.use(shortlistRoutes);
   app.use(adminRoutes);
 
-  app.use((req, res) => res.status(404).json({ error: 'not found' }));
-  app.use((err, req, res, next) => res.status(500).json({ error: 'internal server error' }));
+  app.use((req, res) => sendApiError(res, 'not found', { status: 404 }));
+  app.use((err, req, res, next) => sendApiError(res, err, { status: 500 }));
 }

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -1,49 +1,61 @@
 import { Router } from 'express';
 import { reviewData } from '../data/index.js';
 import { requireAuth } from '../middleware/auth.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.get('/buildings/:id/reviews', async (req, res) => {
-  try {
-    const items = await reviewData.getReviewsByBuilding(req.params.id);
-    res.json({ success: true, data: items });
-  } catch (e) {
-    res.status(404).json({ error: e });
-  }
-});
+router.get(
+  '/buildings/:id/reviews',
+  createApiHandler(
+    async (req) => reviewData.getReviewsByBuilding(req.params.id),
+    { errorStatus: 404 }
+  )
+);
 
-router.post('/buildings/:id/reviews', requireAuth, async (req, res) => {
-  try {
-    const { reviewText, rating, issueTags } = req.body;
-    const result = await reviewData.createReview(
-      req.params.id, req.session.user._id, reviewText, rating, issueTags
-    );
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/buildings/:id/reviews',
+  requireAuth,
+  createApiHandler(
+    async (req) => {
+      const { reviewText, rating, issueTags } = req.body;
+      return reviewData.createReview(
+        req.params.id,
+        req.session.user._id,
+        reviewText,
+        rating,
+        issueTags
+      );
+    },
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.put('/reviews/:id', requireAuth, async (req, res) => {
-  try {
-    const { reviewText, rating, issueTags } = req.body;
-    const result = await reviewData.updateReview(
-      req.params.id, req.session.user._id, reviewText, rating, issueTags
-    );
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.put(
+  '/reviews/:id',
+  requireAuth,
+  createApiHandler(
+    async (req) => {
+      const { reviewText, rating, issueTags } = req.body;
+      return reviewData.updateReview(
+        req.params.id,
+        req.session.user._id,
+        reviewText,
+        rating,
+        issueTags
+      );
+    },
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/reviews/:id', requireAuth, async (req, res) => {
-  try {
-    const result = await reviewData.deleteReview(req.params.id, req.session.user._id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/reviews/:id',
+  requireAuth,
+  createApiHandler(
+    async (req) => reviewData.deleteReview(req.params.id, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/routes/shortlists.js
+++ b/routes/shortlists.js
@@ -1,61 +1,74 @@
 import { Router } from 'express';
 import { shortlistData } from '../data/index.js';
 import { requireAuth } from '../middleware/auth.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.get('/shortlists', requireAuth, async (req, res) => {
-  try {
-    const items = await shortlistData.getShortlistsByUser(req.session.user._id);
-    res.json({ success: true, data: items });
-  } catch (e) {
-    res.status(500).json({ error: e });
-  }
-});
+router.get(
+  '/shortlists',
+  requireAuth,
+  createApiHandler(
+    async (req) => shortlistData.getShortlistsByUser(req.session.user._id),
+    { errorStatus: 500 }
+  )
+);
 
-router.post('/shortlists', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.createShortlist(req.session.user._id, req.body.shortlistName);
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/shortlists',
+  requireAuth,
+  createApiHandler(
+    async (req) => shortlistData.createShortlist(req.session.user._id, req.body.shortlistName),
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.post('/shortlists/:id/items', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.addItemToShortlist(req.params.id, req.session.user._id, req.body.buildingId);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/shortlists/:id/items',
+  requireAuth,
+  createApiHandler(
+    async (req) =>
+      shortlistData.addItemToShortlist(req.params.id, req.session.user._id, req.body.buildingId),
+    { errorStatus: 400 }
+  )
+);
 
-router.patch('/shortlists/:id/items/:buildingId/note', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.updateItemNote(req.params.id, req.session.user._id, req.params.buildingId, req.body.privateNote);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.patch(
+  '/shortlists/:id/items/:buildingId/note',
+  requireAuth,
+  createApiHandler(
+    async (req) =>
+      shortlistData.updateItemNote(
+        req.params.id,
+        req.session.user._id,
+        req.params.buildingId,
+        req.body.privateNote
+      ),
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/shortlists/:id/items/:buildingId', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.removeItemFromShortlist(req.params.id, req.session.user._id, req.params.buildingId);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/shortlists/:id/items/:buildingId',
+  requireAuth,
+  createApiHandler(
+    async (req) =>
+      shortlistData.removeItemFromShortlist(
+        req.params.id,
+        req.session.user._id,
+        req.params.buildingId
+      ),
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/shortlists/:id', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.deleteShortlist(req.params.id, req.session.user._id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/shortlists/:id',
+  requireAuth,
+  createApiHandler(
+    async (req) => shortlistData.deleteShortlist(req.params.id, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/utils/api-response.js
+++ b/utils/api-response.js
@@ -1,0 +1,57 @@
+const DEFAULT_SERVER_ERROR_MESSAGE = 'internal server error';
+
+export const sendApiSuccess = (res, data, status = 200) => {
+  const body = { success: true };
+
+  if (data !== undefined) {
+    body.data = data;
+  }
+
+  return res.status(status).json(body);
+};
+
+export const sendApiError = (
+  res,
+  error,
+  {
+    status = 500,
+    fallbackMessage = DEFAULT_SERVER_ERROR_MESSAGE
+  } = {}
+) => {
+  const message =
+    status >= 500
+      ? fallbackMessage
+      : typeof error === 'string' && error.trim().length > 0
+        ? error
+        : error instanceof Error && error.message
+          ? error.message
+          : fallbackMessage;
+
+  return res.status(status).json({ error: message });
+};
+
+export const createApiHandler = (
+  handler,
+  {
+    successStatus = 200,
+    errorStatus = 500,
+    getErrorStatus,
+    fallbackMessage
+  } = {}
+) =>
+  async (req, res, next) => {
+    try {
+      const result = await handler(req, res, next);
+
+      if (res.headersSent) {
+        return;
+      }
+
+      return result === undefined
+        ? sendApiSuccess(res, undefined, successStatus)
+        : sendApiSuccess(res, result, successStatus);
+    } catch (error) {
+      const status = getErrorStatus ? getErrorStatus(error, req, res, next) : errorStatus;
+      return sendApiError(res, error, { status, fallbackMessage });
+    }
+  };


### PR DESCRIPTION
## Summary

This PR adds a shared API error-response helper for the back end so route handlers return more consistent JSON error responses and use more predictable status-code handling.

### Files changed

- Added a shared API response helper in `utils/api-response.js`.
- Introduced `sendApiError` to centralize JSON error responses.
- Introduced `createApiHandler` to reduce repeated async `try/catch` response logic in route handlers.
- Kept success response shapes compatible with the existing API while centralizing shared response behavior.
- Updated auth and admin/auth middleware to use the shared error helper for `401` and `403` responses.
- Updated route modules to use the shared handler pattern instead of repeating per-route `try/catch` blocks.
- Updated the API fallback handlers so `404` and server errors also use the same error-response helper.

### Route modules updated

- `routes/auth.js`
- `routes/buildings.js`
- `routes/reviews.js`
- `routes/shortlists.js`
- `routes/admin.js`
- `routes/index.js`
- `middleware/auth.js`

## Behavior impact

- Error responses are now produced through one shared helper instead of repeated route-specific logic.
- `401`, `403`, `404`, validation failures, and other route-level errors now follow a more consistent JSON error shape.
- Route handlers are shorter and status-code behavior is easier to reason about.
- Existing success response shapes are preserved.

## Testing

Tested all modified code paths directly.

### Helper verification
- verified `sendApiSuccess` with and without response data
- verified `sendApiError` for client errors and server-error fallback behavior
- verified `createApiHandler` success and error paths

### HTTP route verification
- verified `GET /not-a-route` returns `404` with the shared JSON error response
- verified unauthenticated `POST /watchlist/toggle` returns `401`
- verified non-admin access to admin routes returns `403`
- verified:
  - `POST /auth/register`
  - `POST /auth/login` success and failure
  - `POST /auth/logout`
  - `GET /buildings` success and invalid-query `400`
  - `GET /buildings/:id`
  - `GET /portfolios
