### PR TITLE
feat: add shared API error response helper

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,10 +1,12 @@
+import { sendApiError } from '../utils/api-response.js';
+
 export const requireAuth = (req, res, next) => {
-  if (!req.session.user) return res.status(401).json({ error: 'not authenticated' });
+  if (!req.session.user) return sendApiError(res, 'not authenticated', { status: 401 });
   next();
 };
 
 export const requireAdmin = (req, res, next) => {
-  if (!req.session.user) return res.status(401).json({ error: 'not authenticated' });
-  if (req.session.user.role !== 'admin') return res.status(403).json({ error: 'forbidden' });
+  if (!req.session.user) return sendApiError(res, 'not authenticated', { status: 401 });
+  if (req.session.user.role !== 'admin') return sendApiError(res, 'forbidden', { status: 403 });
   next();
 };

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,34 +1,35 @@
 import { Router } from 'express';
 import { buildingData } from '../data/index.js';
 import { requireAdmin } from '../middleware/auth.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.post('/admin/buildings', requireAdmin, async (req, res) => {
-  try {
-    const result = await buildingData.createBuilding(req.body, req.session.user._id);
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/admin/buildings',
+  requireAdmin,
+  createApiHandler(
+    async (req) => buildingData.createBuilding(req.body, req.session.user._id),
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.put('/admin/buildings/:id', requireAdmin, async (req, res) => {
-  try {
-    const result = await buildingData.updateBuilding(req.params.id, req.body, req.session.user._id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.put(
+  '/admin/buildings/:id',
+  requireAdmin,
+  createApiHandler(
+    async (req) => buildingData.updateBuilding(req.params.id, req.body, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/admin/buildings/:id', requireAdmin, async (req, res) => {
-  try {
-    const result = await buildingData.deleteBuilding(req.params.id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/admin/buildings/:id',
+  requireAdmin,
+  createApiHandler(
+    async (req) => buildingData.deleteBuilding(req.params.id),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,30 +1,34 @@
 import { Router } from 'express';
 import { userData } from '../data/index.js';
+import { createApiHandler, sendApiSuccess } from '../utils/api-response.js';
 
 const router = Router();
 
-router.post('/auth/register', async (req, res) => {
-  try {
-    const { firstName, lastName, email, username, password } = req.body;
-    const result = await userData.createUser(firstName, lastName, email, username, password);
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/auth/register',
+  createApiHandler(
+    async (req) => {
+      const { firstName, lastName, email, username, password } = req.body;
+      return userData.createUser(firstName, lastName, email, username, password);
+    },
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.post('/auth/login', async (req, res) => {
-  try {
-    const user = await userData.loginUser(req.body.username, req.body.password);
-    req.session.user = user;
-    res.json({ success: true, data: user });
-  } catch (e) {
-    res.status(401).json({ error: e });
-  }
-});
+router.post(
+  '/auth/login',
+  createApiHandler(
+    async (req) => {
+      const user = await userData.loginUser(req.body.username, req.body.password);
+      req.session.user = user;
+      return user;
+    },
+    { errorStatus: 401 }
+  )
+);
 
 router.post('/auth/logout', (req, res) => {
-  req.session.destroy(() => res.json({ success: true }));
+  req.session.destroy(() => sendApiSuccess(res));
 });
 
 export default router;

--- a/routes/buildings.js
+++ b/routes/buildings.js
@@ -2,48 +2,46 @@ import { Router } from 'express';
 import { buildingData } from '../data/index.js';
 import { requireAuth } from '../middleware/auth.js';
 import { userData } from '../data/index.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.get('/buildings', async (req, res) => {
-  try {
+router.get(
+  '/buildings',
+  createApiHandler(async (req) => {
     const { search, borough, page, limit } = req.query;
-    const result = await buildingData.getAllBuildings({
-      search, borough,
+    return buildingData.getAllBuildings({
+      search,
+      borough,
       page: page ? parseInt(page) : 1,
       limit: limit ? parseInt(limit) : 20
     });
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(500).json({ error: e });
-  }
-});
+  })
+);
 
-router.get('/buildings/:id', async (req, res) => {
-  try {
-    const building = await buildingData.getBuildingById(req.params.id);
-    res.json({ success: true, data: building });
-  } catch (e) {
-    res.status(404).json({ error: e });
-  }
-});
+router.get(
+  '/buildings/:id',
+  createApiHandler(
+    async (req) => buildingData.getBuildingById(req.params.id),
+    { errorStatus: 404 }
+  )
+);
 
-router.get('/portfolios/:ownerName', async (req, res) => {
-  try {
-    const items = await buildingData.getBuildingsByOwner(req.params.ownerName);
-    res.json({ success: true, data: items });
-  } catch (e) {
-    res.status(404).json({ error: e });
-  }
-});
+router.get(
+  '/portfolios/:ownerName',
+  createApiHandler(
+    async (req) => buildingData.getBuildingsByOwner(req.params.ownerName),
+    { errorStatus: 404 }
+  )
+);
 
-router.post('/watchlist/toggle', requireAuth, async (req, res) => {
-  try {
-    const result = await userData.toggleWatchlist(req.session.user._id, req.body.buildingId);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/watchlist/toggle',
+  requireAuth,
+  createApiHandler(
+    async (req) => userData.toggleWatchlist(req.session.user._id, req.body.buildingId),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ import buildingRoutes from './buildings.js';
 import reviewRoutes from './reviews.js';
 import shortlistRoutes from './shortlists.js';
 import adminRoutes from './admin.js';
+import { sendApiError } from '../utils/api-response.js';
 
 export default function registerRoutes(app) {
   app.use(authRoutes);
@@ -11,6 +12,10 @@ export default function registerRoutes(app) {
   app.use(shortlistRoutes);
   app.use(adminRoutes);
 
-  app.use((req, res) => res.status(404).json({ error: 'not found' }));
-  app.use((err, req, res, next) => res.status(500).json({ error: 'internal server error' }));
+  app.use((req, res) => sendApiError(res, 'not found', { status: 404 }));
+  app.use((err, req, res, next) =>
+    sendApiError(res, err, {
+      status: Number.isInteger(err?.status) ? err.status : Number.isInteger(err?.statusCode) ? err.statusCode : 500
+    })
+  );
 }

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -1,49 +1,61 @@
 import { Router } from 'express';
 import { reviewData } from '../data/index.js';
 import { requireAuth } from '../middleware/auth.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.get('/buildings/:id/reviews', async (req, res) => {
-  try {
-    const items = await reviewData.getReviewsByBuilding(req.params.id);
-    res.json({ success: true, data: items });
-  } catch (e) {
-    res.status(404).json({ error: e });
-  }
-});
+router.get(
+  '/buildings/:id/reviews',
+  createApiHandler(
+    async (req) => reviewData.getReviewsByBuilding(req.params.id),
+    { errorStatus: 404 }
+  )
+);
 
-router.post('/buildings/:id/reviews', requireAuth, async (req, res) => {
-  try {
-    const { reviewText, rating, issueTags } = req.body;
-    const result = await reviewData.createReview(
-      req.params.id, req.session.user._id, reviewText, rating, issueTags
-    );
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/buildings/:id/reviews',
+  requireAuth,
+  createApiHandler(
+    async (req) => {
+      const { reviewText, rating, issueTags } = req.body;
+      return reviewData.createReview(
+        req.params.id,
+        req.session.user._id,
+        reviewText,
+        rating,
+        issueTags
+      );
+    },
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.put('/reviews/:id', requireAuth, async (req, res) => {
-  try {
-    const { reviewText, rating, issueTags } = req.body;
-    const result = await reviewData.updateReview(
-      req.params.id, req.session.user._id, reviewText, rating, issueTags
-    );
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.put(
+  '/reviews/:id',
+  requireAuth,
+  createApiHandler(
+    async (req) => {
+      const { reviewText, rating, issueTags } = req.body;
+      return reviewData.updateReview(
+        req.params.id,
+        req.session.user._id,
+        reviewText,
+        rating,
+        issueTags
+      );
+    },
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/reviews/:id', requireAuth, async (req, res) => {
-  try {
-    const result = await reviewData.deleteReview(req.params.id, req.session.user._id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/reviews/:id',
+  requireAuth,
+  createApiHandler(
+    async (req) => reviewData.deleteReview(req.params.id, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/routes/shortlists.js
+++ b/routes/shortlists.js
@@ -1,61 +1,73 @@
 import { Router } from 'express';
 import { shortlistData } from '../data/index.js';
 import { requireAuth } from '../middleware/auth.js';
+import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
 
-router.get('/shortlists', requireAuth, async (req, res) => {
-  try {
-    const items = await shortlistData.getShortlistsByUser(req.session.user._id);
-    res.json({ success: true, data: items });
-  } catch (e) {
-    res.status(500).json({ error: e });
-  }
-});
+router.get(
+  '/shortlists',
+  requireAuth,
+  createApiHandler(
+    async (req) => shortlistData.getShortlistsByUser(req.session.user._id)
+  )
+);
 
-router.post('/shortlists', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.createShortlist(req.session.user._id, req.body.shortlistName);
-    res.status(201).json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/shortlists',
+  requireAuth,
+  createApiHandler(
+    async (req) => shortlistData.createShortlist(req.session.user._id, req.body.shortlistName),
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
 
-router.post('/shortlists/:id/items', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.addItemToShortlist(req.params.id, req.session.user._id, req.body.buildingId);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.post(
+  '/shortlists/:id/items',
+  requireAuth,
+  createApiHandler(
+    async (req) =>
+      shortlistData.addItemToShortlist(req.params.id, req.session.user._id, req.body.buildingId),
+    { errorStatus: 400 }
+  )
+);
 
-router.patch('/shortlists/:id/items/:buildingId/note', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.updateItemNote(req.params.id, req.session.user._id, req.params.buildingId, req.body.privateNote);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.patch(
+  '/shortlists/:id/items/:buildingId/note',
+  requireAuth,
+  createApiHandler(
+    async (req) =>
+      shortlistData.updateItemNote(
+        req.params.id,
+        req.session.user._id,
+        req.params.buildingId,
+        req.body.privateNote
+      ),
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/shortlists/:id/items/:buildingId', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.removeItemFromShortlist(req.params.id, req.session.user._id, req.params.buildingId);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/shortlists/:id/items/:buildingId',
+  requireAuth,
+  createApiHandler(
+    async (req) =>
+      shortlistData.removeItemFromShortlist(
+        req.params.id,
+        req.session.user._id,
+        req.params.buildingId
+      ),
+    { errorStatus: 400 }
+  )
+);
 
-router.delete('/shortlists/:id', requireAuth, async (req, res) => {
-  try {
-    const result = await shortlistData.deleteShortlist(req.params.id, req.session.user._id);
-    res.json({ success: true, data: result });
-  } catch (e) {
-    res.status(400).json({ error: e });
-  }
-});
+router.delete(
+  '/shortlists/:id',
+  requireAuth,
+  createApiHandler(
+    async (req) => shortlistData.deleteShortlist(req.params.id, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
 
 export default router;

--- a/utils/api-response.js
+++ b/utils/api-response.js
@@ -1,0 +1,84 @@
+const DEFAULT_SERVER_ERROR_MESSAGE = 'internal server error';
+
+const isValidHttpStatus = (value) =>
+  Number.isInteger(value) && value >= 400 && value <= 599;
+
+const getErrorStatusFromObject = (error) => {
+  if (isValidHttpStatus(error?.status)) {
+    return error.status;
+  }
+
+  if (isValidHttpStatus(error?.statusCode)) {
+    return error.statusCode;
+  }
+
+  return undefined;
+};
+
+const resolveApiErrorStatus = (error, errorStatus, getErrorStatus) => {
+  const errorStatusFromObject = getErrorStatusFromObject(error);
+
+  if (errorStatusFromObject !== undefined) {
+    return errorStatusFromObject;
+  }
+
+  if (typeof getErrorStatus === 'function') {
+    return getErrorStatus(error);
+  }
+
+  return error instanceof Error ? 500 : errorStatus;
+};
+
+export const sendApiSuccess = (res, data, status = 200) => {
+  const body = { success: true };
+
+  if (data !== undefined) {
+    body.data = data;
+  }
+
+  return res.status(status).json(body);
+};
+
+export const sendApiError = (
+  res,
+  error,
+  {
+    status = 500,
+    fallbackMessage = DEFAULT_SERVER_ERROR_MESSAGE
+  } = {}
+) => {
+  const message =
+    status >= 500
+      ? fallbackMessage
+      : typeof error === 'string' && error.trim().length > 0
+        ? error
+        : error instanceof Error && error.message
+          ? error.message
+          : fallbackMessage;
+
+  return res.status(status).json({ error: message });
+};
+
+export const createApiHandler = (
+  handler,
+  {
+    successStatus = 200,
+    errorStatus = 500,
+    getErrorStatus,
+    fallbackMessage
+  } = {}
+) =>
+  async (req, res, next) => {
+    try {
+      const result = await handler(req, res, next);
+
+      if (res.headersSent) {
+        return;
+      }
+
+      return sendApiSuccess(res, result, successStatus);
+    } catch (error) {
+      const status = resolveApiErrorStatus(error, errorStatus, getErrorStatus);
+      return sendApiError(res, error, { status, fallbackMessage });
+    }
+  };


### PR DESCRIPTION
## Summary

This PR adds a shared API error-response helper for the back end so route handlers return more consistent JSON error responses and rely less on repeated `try/catch` response logic.

### Files changed

- added `utils/api-response.js` as a shared response helper
- introduced `sendApiError` to centralize JSON error responses
- introduced `sendApiSuccess` to preserve the existing success response shape
- introduced `createApiHandler` to wrap async route handlers and reduce repeated route-level `try/catch` blocks
- updated `middleware/auth.js` to use the shared helper for `401` and `403` responses
- updated `routes/auth.js`, `routes/buildings.js`, `routes/reviews.js`, `routes/shortlists.js`, and `routes/admin.js` to use the shared handler pattern
- updated `routes/index.js` so `404` and global error responses also use the shared error helper
- preserved existing success response structure while centralizing error handling
- allowed the helper to respect `error.status` / `error.statusCode` when available, so framework-level errors can return more appropriate status codes

## Behavior impact

- error responses are now generated through one shared helper instead of repeated per-route logic
- route handlers are shorter and status-code behavior is more predictable
- auth middleware, not-found responses, and global error handling now follow the same response path
- existing success response shapes are preserved

## Testing

Tested all modified code directly.

### Helper verification
- verified `sendApiSuccess` with and without response data
- verified `sendApiError` for client errors and server-error fallback behavior
- verified `createApiHandler` success path
- verified `createApiHandler` string-error path
- verified `createApiHandler` respects `error.status`

### HTTP verification
- verified malformed JSON request hits the shared error middleware path
- verified `GET /not-a-route` returns `404`
- verified unauthenticated access returns `401`
- verified non-admin access to admin routes returns `403`
- verified:
  - `POST /auth/register`
  - `POST /auth/login` success and failure
  - `POST /auth/logout`
  - `GET /buildings`
  - `GET /buildings/:id`
  - `GET /portfolios/:ownerName`
  - `POST /watchlist/toggle`
  - `GET /buildings/:id/reviews`
  - `POST /buildings/:id/reviews`
  - `PUT /reviews/:id`
  - `DELETE /reviews/:id`
  - `GET /shortlists`
  - `POST /shortlists`
  - `POST /shortlists/:id/items`
  - `PATCH /shortlists/:id/items/:buildingId/note`
  - `DELETE /shortlists/:id/items/:buildingId`
  - `DELETE /shortlists/:id`
  - `POST /admin/buildings`
  - `PUT /admin/buildings/:id`
  - `DELETE /admin/buildings/:id`

### Notes
- verification was done with real local HTTP requests
- temporary verification data was cleaned up after testing
- the temporary local server used for verification was stopped after the checks completed