### PR TITLE
implement database seed script

### DIFF
--- a/tasks/prepareSeedData.js
+++ b/tasks/prepareSeedData.js
@@ -1,0 +1,145 @@
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Input and output paths
+const inputPath = path.join(__dirname, "raw-data", "queens_buildings_seed.csv");
+const outputDir = path.join(__dirname, "seed-data");
+const outputPath = path.join(outputDir, "buildings.json");
+
+const normalizeBorough = (boro) => {
+  if (!boro) return "";
+  const value = boro.toString().trim().toUpperCase();
+
+  const map = {
+    MANHATTAN: "Manhattan",
+    BROOKLYN: "Brooklyn",
+    QUEENS: "Queens",
+    BRONX: "Bronx",
+    "STATEN ISLAND": "Staten Island",
+  };
+
+  return map[value] || boro.toString().trim();
+};
+
+const safeString = (value) => {
+  if (value === null || value === undefined) return "";
+  return value.toString().trim();
+};
+
+const buildStreetAddress = (houseNumber, streetName) => {
+  return `${safeString(houseNumber)} ${safeString(streetName)}`.trim();
+};
+
+const buildBBL = (block, lot) => {
+  const cleanBlock = safeString(block);
+  const cleanLot = safeString(lot);
+
+  if (!cleanBlock || !cleanLot) return "";
+  return `${cleanBlock}-${cleanLot}`;
+};
+
+const isUsableRow = (row) => {
+  const recordStatus = safeString(row.RecordStatus || row.recordstatus);
+  const houseNumber = safeString(row.HouseNumber || row.housenumber);
+  const streetName = safeString(row.StreetName || row.streetname);
+  const zip = safeString(row.Zip || row.zip);
+  const bin = safeString(row.BIN || row.bin);
+  const boro = safeString(row.Boro || row.boro);
+
+  if (recordStatus.toUpperCase() !== "ACTIVE") return false;
+  if (!houseNumber) return false;
+  if (!streetName) return false;
+  if (!zip) return false;
+  if (!bin) return false;
+  if (!boro) return false;
+
+  return true;
+};
+
+const transformRowToBuilding = (row) => {
+  const houseNumber = safeString(row.HouseNumber || row.housenumber);
+  const streetName = safeString(row.StreetName || row.streetname);
+  const borough = normalizeBorough(row.Boro || row.boro);
+  const zipCode = safeString(row.Zip || row.zip);
+  const bin = safeString(row.BIN || row.bin);
+  const block = safeString(row.Block || row.block);
+  const lot = safeString(row.Lot || row.lot);
+  const registrationId = safeString(row.RegistrationID || row.registrationid);
+  const recordStatus = safeString(row.RecordStatus || row.recordstatus);
+
+  return {
+    buildingName: "",
+    streetAddress: buildStreetAddress(houseNumber, streetName),
+    borough,
+    neighborhood: "",
+    zipCode,
+    bin,
+    bbl: buildBBL(block, lot),
+    ownerName: "",
+    managerName: "",
+    riskSummary: {
+      highlights: [],
+      lastCalculatedAt: new Date().toISOString(),
+    },
+    housingRecords: [
+      {
+        sourceDataset: "Buildings Subject to HPD Jurisdiction",
+        recordType: "registration",
+        category: `HPD jurisdiction${registrationId ? ` / registration ${registrationId}` : ""}`,
+        status: recordStatus.toLowerCase(),
+        recordDate: new Date().toISOString(),
+      },
+    ],
+  };
+};
+
+const dedupeBuildings = (buildings) => {
+  const seen = new Set();
+  const result = [];
+
+  for (const building of buildings) {
+    const key = `${building.bin}|${building.streetAddress}|${building.zipCode}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(building);
+    }
+  }
+
+  return result;
+};
+
+const main = async () => {
+  try {
+    const csvText = fs.readFileSync(inputPath, "utf8");
+
+    const records = parse(csvText, {
+      columns: true,
+      skip_empty_lines: true,
+      bom: true,
+    });
+
+    const usableRows = records.filter(isUsableRow);
+    const transformed = usableRows.map(transformRowToBuilding);
+    const deduped = dedupeBuildings(transformed);
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    fs.writeFileSync(outputPath, JSON.stringify(deduped, null, 2), "utf8");
+
+    console.log(`Read ${records.length} rows from CSV.`);
+    console.log(`Kept ${usableRows.length} usable rows.`);
+    console.log(`Wrote ${deduped.length} buildings to ${outputPath}.`);
+  } catch (error) {
+    console.error("Failed to prepare seed data:", error);
+    process.exit(1);
+  }
+};
+
+main();

--- a/tasks/seed-data/buildings.json
+++ b/tasks/seed-data/buildings.json
@@ -1,0 +1,1178 @@
+[
+  {
+    "buildingName": "",
+    "streetAddress": "198-06 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232261",
+    "bbl": "10865-3",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "219-40 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230917",
+    "bbl": "10773-121",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "218-33 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230849",
+    "bbl": "10768-46",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "222-18 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4231311",
+    "bbl": "10803-8",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "218-50 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4456931",
+    "bbl": "10767-28",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "217-40 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230676",
+    "bbl": "10761-25",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 418747",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "193-01 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231778",
+    "bbl": "10840-1",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "193-14 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232145",
+    "bbl": "10860-44",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "193-16 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232146",
+    "bbl": "10860-47",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "193-17 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231789",
+    "bbl": "10840-31",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "194-01 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231804",
+    "bbl": "10841-34",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "194-02 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232169",
+    "bbl": "10861-27",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "194-03 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231803",
+    "bbl": "10841-32",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "194-14 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232171",
+    "bbl": "10861-33",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "195-15 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231823",
+    "bbl": "10842-28",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "196-06 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232205",
+    "bbl": "10863-3",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "196-10 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232206",
+    "bbl": "10863-5",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "196-11 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231839",
+    "bbl": "10843-23",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "196-14 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232207",
+    "bbl": "10863-7",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "196-17 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231837",
+    "bbl": "10843-19",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "197-02 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232230",
+    "bbl": "10864-1",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "197-03 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231858",
+    "bbl": "10844-27",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "197-14 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232233",
+    "bbl": "10864-7",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "197-17 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231854",
+    "bbl": "10844-19",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 923406",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "197-18 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232234",
+    "bbl": "10864-9",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "198-09 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231868",
+    "bbl": "10845-23",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "198-12 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232263",
+    "bbl": "10865-6",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "198-14 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232264",
+    "bbl": "10865-7",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "199-03 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231892",
+    "bbl": "10846-26",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "200-02 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232317",
+    "bbl": "10867-1",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "200-18 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232320",
+    "bbl": "10867-9",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "201-07 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231923",
+    "bbl": "10848-24",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "201-11 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231922",
+    "bbl": "10848-22",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "201-14 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232347",
+    "bbl": "10868-7",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "201-17 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231920",
+    "bbl": "10848-18",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "201-18 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232348",
+    "bbl": "10868-9",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "202-02 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4232383",
+    "bbl": "10869-1",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "202-15 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231938",
+    "bbl": "10849-21",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "218-13 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4434674",
+    "bbl": "10768-56",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 419533",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "205-03 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231990",
+    "bbl": "10852-25",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "218-40 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230802",
+    "bbl": "10767-24",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "217-18 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230670",
+    "bbl": "10761-12",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "217-04 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230664",
+    "bbl": "10761-5",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "217-08 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230666",
+    "bbl": "10761-8",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 921392",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "217-28 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230673",
+    "bbl": "10761-17",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "218-08 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230796",
+    "bbl": "10767-10",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "203-19 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11423",
+    "bin": "4231956",
+    "bbl": "10850-18",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 926140",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "218-35 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230848",
+    "bbl": "10768-45",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  },
+  {
+    "buildingName": "",
+    "streetAddress": "217-10 100 AVENUE",
+    "borough": "Queens",
+    "neighborhood": "",
+    "zipCode": "11429",
+    "bin": "4230667",
+    "bbl": "10761-9",
+    "ownerName": "",
+    "managerName": "",
+    "riskSummary": {
+      "highlights": [],
+      "lastCalculatedAt": "2026-04-22T01:46:32.418Z"
+    },
+    "housingRecords": [
+      {
+        "sourceDataset": "Buildings Subject to HPD Jurisdiction",
+        "recordType": "registration",
+        "category": "HPD jurisdiction / registration 0",
+        "status": "active",
+        "recordDate": "2026-04-22T01:46:32.418Z"
+      }
+    ]
+  }
+]

--- a/tasks/seed.js
+++ b/tasks/seed.js
@@ -1,36 +1,335 @@
-import { dbConnection, closeConnection } from '../config/mongoConnection.js';
-import { userData } from '../data/index.js';
-import { buildings } from '../config/mongoCollections.js';
+import { closeConnection } from "../config/mongoConnection.js";
+import {
+  users,
+  buildings,
+  reviews,
+  shortlists,
+} from "../config/mongoCollections.js";
+
+import { createUser, toggleWatchlist } from "../data/users.js";
+import { createBuilding } from "../data/buildings.js";
+import { createReview } from "../data/reviews.js";
+import {
+  createShortlist,
+  addItemToShortlist,
+  updateItemNote,
+} from "../data/shortlists.js";
 
 const seed = async () => {
-  const db = await dbConnection();
-  await db.dropDatabase();
+  try {
+    // Clear existing data
+    const reviewCollection = await reviews();
+    const shortlistCollection = await shortlists();
+    const buildingCollection = await buildings();
+    const userCollection = await users();
 
-  // Seed admin user
-  await userData.createUser('Admin', 'User', 'admin@leasewise.com', 'admin', 'Admin1234!', 'admin');
+    await reviewCollection.deleteMany({});
+    await shortlistCollection.deleteMany({});
+    await buildingCollection.deleteMany({});
+    await userCollection.deleteMany({});
 
-  // Seed sample building
-  const col = await buildings();
-  await col.insertOne({
-    buildingName: 'Sample Building',
-    streetAddress: '100 Main St',
-    borough: 'Manhattan',
-    neighborhood: 'Midtown',
-    zipCode: '10001',
-    bin: '1000000',
-    bbl: '1000000001',
-    ownerName: 'Sample Owner LLC',
-    managerName: 'Sample Management',
-    riskSummary: { highlights: [], lastCalculatedAt: new Date() },
-    housingRecords: [],
-    createdByAdminId: null,
-    updatedByAdminId: null,
-    createdAt: new Date(),
-    updatedAt: new Date()
-  });
+    console.log("Old data removed.");
 
-  console.log('Seed complete.');
-  await closeConnection();
+    // ----------------------------
+    // Seed users
+    // ----------------------------
+    const admin = await createUser(
+      "Admin",
+      "User",
+      "admin@leasewise.com",
+      "admin",
+      "Admin1234!",
+      "admin",
+    );
+
+    const cindy = await createUser(
+      "Cindy",
+      "Xin",
+      "cindy@example.com",
+      "cindyx",
+      "Password123!",
+      "user",
+    );
+
+    const peter = await createUser(
+      "Peter",
+      "Liao",
+      "peter@example.com",
+      "peterl",
+      "Password123!",
+      "user",
+    );
+
+    const amy = await createUser(
+      "Amy",
+      "Chen",
+      "amy@example.com",
+      "amyc",
+      "Password123!",
+      "user",
+    );
+
+    console.log("Users seeded.");
+
+    // ----------------------------
+    // Seed buildings
+    // ----------------------------
+    const building1 = await createBuilding(
+      {
+        buildingName: "The Hudson Arms",
+        streetAddress: "123 W 110th St",
+        borough: "Manhattan",
+        neighborhood: "Morningside Heights",
+        zipCode: "10026",
+        bin: "1000001",
+        bbl: "1012340001",
+        ownerName: "Hudson Property LLC",
+        managerName: "CityLine Management",
+        riskSummary: {
+          highlights: ["Repeated heat complaints", "Open severe violations"],
+          lastCalculatedAt: new Date("2026-03-10T12:00:00Z"),
+        },
+        housingRecords: [
+          {
+            sourceDataset: "Housing Maintenance Code Complaints and Problems",
+            recordType: "complaint",
+            category: "heat/hot water",
+            status: "open",
+            recordDate: new Date("2026-03-10T00:00:00Z"),
+          },
+          {
+            sourceDataset: "Housing Maintenance Code Violations",
+            recordType: "violation",
+            category: "mold",
+            status: "open",
+            recordDate: new Date("2026-02-21T00:00:00Z"),
+          },
+        ],
+      },
+      admin._id,
+    );
+
+    const building2 = await createBuilding(
+      {
+        buildingName: "Riverside Court",
+        streetAddress: "455 Riverside Dr",
+        borough: "Manhattan",
+        neighborhood: "Hamilton Heights",
+        zipCode: "10031",
+        bin: "1000002",
+        bbl: "1012340002",
+        ownerName: "Riverside Homes Inc",
+        managerName: "Metro Property Services",
+        riskSummary: {
+          highlights: ["Bedbug history reported in prior year"],
+          lastCalculatedAt: new Date("2026-03-08T10:30:00Z"),
+        },
+        housingRecords: [
+          {
+            sourceDataset: "Bedbug Reporting",
+            recordType: "bedbug report",
+            category: "bedbugs",
+            status: "resolved",
+            recordDate: new Date("2025-11-15T00:00:00Z"),
+          },
+          {
+            sourceDataset: "Housing Maintenance Code Complaints and Problems",
+            recordType: "complaint",
+            category: "repairs",
+            status: "closed",
+            recordDate: new Date("2026-01-18T00:00:00Z"),
+          },
+        ],
+      },
+      admin._id,
+    );
+
+    const building3 = await createBuilding(
+      {
+        buildingName: "Brooklyn Terrace",
+        streetAddress: "88 Flatbush Ave",
+        borough: "Brooklyn",
+        neighborhood: "Downtown Brooklyn",
+        zipCode: "11217",
+        bin: "2000001",
+        bbl: "3012340001",
+        ownerName: "Brooklyn Terrace Group",
+        managerName: "Harbor Management NYC",
+        riskSummary: {
+          highlights: ["Litigation activity on record"],
+          lastCalculatedAt: new Date("2026-03-05T09:00:00Z"),
+        },
+        housingRecords: [
+          {
+            sourceDataset: "Housing Litigations",
+            recordType: "litigation",
+            category: "tenant action",
+            status: "open",
+            recordDate: new Date("2026-02-12T00:00:00Z"),
+          },
+          {
+            sourceDataset: "Housing Maintenance Code Violations",
+            recordType: "violation",
+            category: "elevator",
+            status: "resolved",
+            recordDate: new Date("2026-01-28T00:00:00Z"),
+          },
+        ],
+      },
+      admin._id,
+    );
+
+    const building4 = await createBuilding(
+      {
+        buildingName: "Queens Garden Plaza",
+        streetAddress: "240-15 Union Tpke",
+        borough: "Queens",
+        neighborhood: "Bayside",
+        zipCode: "11364",
+        bin: "4000001",
+        bbl: "4012340001",
+        ownerName: "Queens Garden Realty",
+        managerName: "Eastborough Residential",
+        riskSummary: {
+          highlights: ["Low recent complaint volume"],
+          lastCalculatedAt: new Date("2026-03-01T08:45:00Z"),
+        },
+        housingRecords: [
+          {
+            sourceDataset: "Multiple Dwelling Registrations",
+            recordType: "registration",
+            category: "registration active",
+            status: "active",
+            recordDate: new Date("2026-01-01T00:00:00Z"),
+          },
+        ],
+      },
+      admin._id,
+    );
+
+    console.log("Buildings seeded.");
+
+    // ----------------------------
+    // Seed reviews
+    // ----------------------------
+    await createReview(
+      building1._id,
+      cindy._id,
+      "The location is convenient, but the heat issues in winter were very frustrating.",
+      3,
+      ["heat", "maintenance"],
+    );
+
+    await createReview(
+      building1._id,
+      peter._id,
+      "I liked the neighborhood, but the open violations would make me think twice.",
+      2,
+      ["violations", "repairs"],
+    );
+
+    await createReview(
+      building2._id,
+      amy._id,
+      "Management responded fairly quickly, and the building felt safer than expected.",
+      4,
+      ["responsiveness"],
+    );
+
+    await createReview(
+      building2._id,
+      cindy._id,
+      "Past bedbug history is a concern, but the recent records looked better.",
+      3,
+      ["bedbugs"],
+    );
+
+    await createReview(
+      building3._id,
+      peter._id,
+      "The unit layout was nice, but I was concerned after seeing litigation history.",
+      2,
+      ["litigation"],
+    );
+
+    await createReview(
+      building4._id,
+      amy._id,
+      "This was one of the cleaner options I checked, and the records looked relatively calm.",
+      5,
+      ["overall"],
+    );
+
+    console.log("Reviews seeded.");
+
+    // ----------------------------
+    // Seed shortlists
+    // ----------------------------
+    const cindyShortlist = await createShortlist(
+      cindy._id,
+      "My Apartment Hunt",
+    );
+    await addItemToShortlist(cindyShortlist._id, cindy._id, building1._id);
+    await addItemToShortlist(cindyShortlist._id, cindy._id, building2._id);
+    await addItemToShortlist(cindyShortlist._id, cindy._id, building4._id);
+
+    await updateItemNote(
+      cindyShortlist._id,
+      cindy._id,
+      building1._id,
+      "Great location, but I need to ask more about heat complaints.",
+    );
+    await updateItemNote(
+      cindyShortlist._id,
+      cindy._id,
+      building2._id,
+      "Worth comparing because management seems somewhat responsive.",
+    );
+    await updateItemNote(
+      cindyShortlist._id,
+      cindy._id,
+      building4._id,
+      "Looks like the safest option so far.",
+    );
+
+    const peterShortlist = await createShortlist(
+      peter._id,
+      "Buildings to Compare",
+    );
+    await addItemToShortlist(peterShortlist._id, peter._id, building2._id);
+    await addItemToShortlist(peterShortlist._id, peter._id, building3._id);
+
+    await updateItemNote(
+      peterShortlist._id,
+      peter._id,
+      building2._id,
+      "Need to verify if the bedbug issue is fully resolved.",
+    );
+    await updateItemNote(
+      peterShortlist._id,
+      peter._id,
+      building3._id,
+      "Check whether litigation is still active before considering.",
+    );
+
+    console.log("Shortlists seeded.");
+
+    // ----------------------------
+    // Seed watchlists
+    // ----------------------------
+    await toggleWatchlist(cindy._id, building1._id);
+    await toggleWatchlist(cindy._id, building4._id);
+
+    await toggleWatchlist(peter._id, building2._id);
+    await toggleWatchlist(amy._id, building3._id);
+
+    console.log("Watchlists seeded.");
+    console.log("Seed complete.");
+  } catch (e) {
+    console.error("Seed failed:", e);
+  } finally {
+    await closeConnection();
+  }
 };
 
-seed().catch((e) => { console.error(e); process.exit(1); });
+seed();

--- a/tasks/seed.js
+++ b/tasks/seed.js
@@ -1,3 +1,7 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
 import { closeConnection } from "../config/mongoConnection.js";
 import {
   users,
@@ -15,9 +19,14 @@ import {
   updateItemNote,
 } from "../data/shortlists.js";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const seed = async () => {
   try {
+    // ----------------------------
     // Clear existing data
+    // ----------------------------
     const reviewCollection = await reviews();
     const shortlistCollection = await shortlists();
     const buildingCollection = await buildings();
@@ -72,142 +81,31 @@ const seed = async () => {
     console.log("Users seeded.");
 
     // ----------------------------
-    // Seed buildings
+    // Seed buildings from JSON
     // ----------------------------
-    const building1 = await createBuilding(
-      {
-        buildingName: "The Hudson Arms",
-        streetAddress: "123 W 110th St",
-        borough: "Manhattan",
-        neighborhood: "Morningside Heights",
-        zipCode: "10026",
-        bin: "1000001",
-        bbl: "1012340001",
-        ownerName: "Hudson Property LLC",
-        managerName: "CityLine Management",
-        riskSummary: {
-          highlights: ["Repeated heat complaints", "Open severe violations"],
-          lastCalculatedAt: new Date("2026-03-10T12:00:00Z"),
-        },
-        housingRecords: [
-          {
-            sourceDataset: "Housing Maintenance Code Complaints and Problems",
-            recordType: "complaint",
-            category: "heat/hot water",
-            status: "open",
-            recordDate: new Date("2026-03-10T00:00:00Z"),
-          },
-          {
-            sourceDataset: "Housing Maintenance Code Violations",
-            recordType: "violation",
-            category: "mold",
-            status: "open",
-            recordDate: new Date("2026-02-21T00:00:00Z"),
-          },
-        ],
-      },
-      admin._id,
-    );
+    const buildingsPath = path.join(__dirname, "seed-data", "buildings.json");
+    const buildingsData = JSON.parse(fs.readFileSync(buildingsPath, "utf8"));
 
-    const building2 = await createBuilding(
-      {
-        buildingName: "Riverside Court",
-        streetAddress: "455 Riverside Dr",
-        borough: "Manhattan",
-        neighborhood: "Hamilton Heights",
-        zipCode: "10031",
-        bin: "1000002",
-        bbl: "1012340002",
-        ownerName: "Riverside Homes Inc",
-        managerName: "Metro Property Services",
-        riskSummary: {
-          highlights: ["Bedbug history reported in prior year"],
-          lastCalculatedAt: new Date("2026-03-08T10:30:00Z"),
-        },
-        housingRecords: [
-          {
-            sourceDataset: "Bedbug Reporting",
-            recordType: "bedbug report",
-            category: "bedbugs",
-            status: "resolved",
-            recordDate: new Date("2025-11-15T00:00:00Z"),
-          },
-          {
-            sourceDataset: "Housing Maintenance Code Complaints and Problems",
-            recordType: "complaint",
-            category: "repairs",
-            status: "closed",
-            recordDate: new Date("2026-01-18T00:00:00Z"),
-          },
-        ],
-      },
-      admin._id,
-    );
+    if (!Array.isArray(buildingsData) || buildingsData.length === 0) {
+      throw new Error("buildings.json is missing or empty.");
+    }
 
-    const building3 = await createBuilding(
-      {
-        buildingName: "Brooklyn Terrace",
-        streetAddress: "88 Flatbush Ave",
-        borough: "Brooklyn",
-        neighborhood: "Downtown Brooklyn",
-        zipCode: "11217",
-        bin: "2000001",
-        bbl: "3012340001",
-        ownerName: "Brooklyn Terrace Group",
-        managerName: "Harbor Management NYC",
-        riskSummary: {
-          highlights: ["Litigation activity on record"],
-          lastCalculatedAt: new Date("2026-03-05T09:00:00Z"),
-        },
-        housingRecords: [
-          {
-            sourceDataset: "Housing Litigations",
-            recordType: "litigation",
-            category: "tenant action",
-            status: "open",
-            recordDate: new Date("2026-02-12T00:00:00Z"),
-          },
-          {
-            sourceDataset: "Housing Maintenance Code Violations",
-            recordType: "violation",
-            category: "elevator",
-            status: "resolved",
-            recordDate: new Date("2026-01-28T00:00:00Z"),
-          },
-        ],
-      },
-      admin._id,
-    );
+    const createdBuildings = [];
 
-    const building4 = await createBuilding(
-      {
-        buildingName: "Queens Garden Plaza",
-        streetAddress: "240-15 Union Tpke",
-        borough: "Queens",
-        neighborhood: "Bayside",
-        zipCode: "11364",
-        bin: "4000001",
-        bbl: "4012340001",
-        ownerName: "Queens Garden Realty",
-        managerName: "Eastborough Residential",
-        riskSummary: {
-          highlights: ["Low recent complaint volume"],
-          lastCalculatedAt: new Date("2026-03-01T08:45:00Z"),
-        },
-        housingRecords: [
-          {
-            sourceDataset: "Multiple Dwelling Registrations",
-            recordType: "registration",
-            category: "registration active",
-            status: "active",
-            recordDate: new Date("2026-01-01T00:00:00Z"),
-          },
-        ],
-      },
-      admin._id,
-    );
+    for (const building of buildingsData) {
+      const created = await createBuilding(building, admin._id);
+      createdBuildings.push(created);
+    }
 
-    console.log("Buildings seeded.");
+    console.log(`Buildings seeded: ${createdBuildings.length}`);
+
+    if (createdBuildings.length < 4) {
+      throw new Error(
+        "Need at least 4 buildings in buildings.json for reviews and shortlists.",
+      );
+    }
+
+    const [building1, building2, building3, building4] = createdBuildings;
 
     // ----------------------------
     // Seed reviews
@@ -269,6 +167,7 @@ const seed = async () => {
       cindy._id,
       "My Apartment Hunt",
     );
+
     await addItemToShortlist(cindyShortlist._id, cindy._id, building1._id);
     await addItemToShortlist(cindyShortlist._id, cindy._id, building2._id);
     await addItemToShortlist(cindyShortlist._id, cindy._id, building4._id);
@@ -296,6 +195,7 @@ const seed = async () => {
       peter._id,
       "Buildings to Compare",
     );
+
     await addItemToShortlist(peterShortlist._id, peter._id, building2._id);
     await addItemToShortlist(peterShortlist._id, peter._id, building3._id);
 


### PR DESCRIPTION
This PR adds a repeatable database seed script for the back-end project.

Included seeded data:

* admin and sample users
* sample buildings
* reviews
* shortlists with notes
* watchlist relationships

This should help the team test core features more easily during development.
