### PR TITLE
feat: validate review issue tags

### DIFF
--- a/data/validation.js
+++ b/data/validation.js
@@ -390,6 +390,7 @@ export const checkIssueTags = (val, name = 'issueTags', options = {}) => {
     trim: true,
     caseInsensitive: true,
     allowedValues: REVIEW_ISSUE_TAG_VALUES,
+    maxItems,
     itemMaxLength: VALIDATION_LIMITS.issueTagMaxLength,
     ...arrayOptions
   });
@@ -401,10 +402,6 @@ export const checkIssueTags = (val, name = 'issueTags', options = {}) => {
       seen.add(tag);
       uniqueTags.push(tag);
     }
-  }
-
-  if (maxItems !== undefined && uniqueTags.length > maxItems) {
-    throw `${name} must contain at most ${maxItems} item${maxItems === 1 ? '' : 's'}`;
   }
 
   return uniqueTags;

--- a/data/validation.js
+++ b/data/validation.js
@@ -13,6 +13,18 @@ export const BOROUGH_VALUES = Object.freeze([
 
 export const USER_ROLE_VALUES = Object.freeze(['user', 'admin']);
 
+export const REVIEW_ISSUE_TAG_VALUES = Object.freeze([
+  'heat',
+  'pests',
+  'repairs',
+  'responsiveness',
+  'maintenance',
+  'violations',
+  'bedbugs',
+  'litigation',
+  'overall'
+]);
+
 export const VALIDATION_LIMITS = Object.freeze({
   textMaxLength: 5000,
   emailMaxLength: 254,
@@ -366,15 +378,37 @@ export const checkStringArray = (
   return normalized;
 };
 
-export const checkIssueTags = (val, name = 'issueTags', options = {}) =>
-  checkStringArray(val, name, {
+export const checkIssueTags = (val, name = 'issueTags', options = {}) => {
+  const {
+    maxItems = VALIDATION_LIMITS.issueTagMaxItems,
+    allowedValues: _allowedValuesIgnored,
+    caseInsensitive: _caseInsensitiveIgnored,
+    unique: _uniqueIgnored,
+    ...arrayOptions
+  } = options;
+  const normalizedTags = checkStringArray(val, name, {
     trim: true,
     caseInsensitive: true,
-    unique: true,
-    maxItems: VALIDATION_LIMITS.issueTagMaxItems,
+    allowedValues: REVIEW_ISSUE_TAG_VALUES,
     itemMaxLength: VALIDATION_LIMITS.issueTagMaxLength,
-    ...options
+    ...arrayOptions
   });
+  const uniqueTags = [];
+  const seen = new Set();
+
+  for (const tag of normalizedTags) {
+    if (!seen.has(tag)) {
+      seen.add(tag);
+      uniqueTags.push(tag);
+    }
+  }
+
+  if (maxItems !== undefined && uniqueTags.length > maxItems) {
+    throw `${name} must contain at most ${maxItems} item${maxItems === 1 ? '' : 's'}`;
+  }
+
+  return uniqueTags;
+};
 
 export const checkInt = (val, name = 'value', min, max) => {
   if (typeof val !== 'number' || !Number.isInteger(val)) throw `${name} must be an integer`;


### PR DESCRIPTION
## Summary

This PR tightens review `issueTags` validation so review payloads are controlled, normalized, and predictable.

### What changed

- Added an approved review issue tag list in `data/validation.js`.
- Limited review `issueTags` to approved values only.
- Normalized accepted tags to canonical lowercase values.
- Trimmed tag values before validation.
- Removed duplicate tags automatically while preserving the original valid tag order.
- Rejected malformed `issueTags` payloads, including non-array values, non-string items, empty strings, and unapproved tags.

## Approved Tags

- `heat`
- `pests`
- `repairs`
- `responsiveness`
- `maintenance`
- `violations`
- `bedbugs`
- `litigation`
- `overall`

## Behavior impact

- Valid review tags are stored consistently.
- Duplicate tags like `["Heat", "heat", "PESTS"]` are normalized to `["heat", "pests"]`.
- Invalid tags like `noise` are rejected.
- Malformed payloads like `issueTags: "heat"` are rejected.
- Existing `createReview` and `updateReview` flows now receive stricter tag validation through the shared helper.

## Files Changed

- `data/validation.js`

## Testing

Verified the following:

- Updated validation and review modules import successfully.
- `checkIssueTags` accepts approved tags.
- `checkIssueTags` normalizes casing and trims values.
- Duplicate tags are removed.
- Unapproved tags are rejected.
- Malformed payloads are rejected.
- Mongo-backed `createReview` stores normalized unique tags.
- Mongo-backed `updateReview` stores normalized unique tags.
- HTTP review creation accepts valid normalized tags and stores them correctly.
- HTTP review creation rejects unapproved tags with `400`.
- HTTP review creation rejects malformed `issueTags` with `400`.
- `git diff --check` passes.

## Notes

- Temporary MongoDB test data was cleaned up after verification.
- The temporary local backend server used for HTTP verification was stopped after testing.
- No full test suite was run because the backend repository does not currently define a test script.
