### PR TITLE
feat: add admin user management endpoints

### DIFF
--- a/data/users.js
+++ b/data/users.js
@@ -23,6 +23,22 @@ const normalizeLoginCredential = (value) =>
         value: checkUsername(value, "username"),
       };
 
+const serializeUserForAdmin = (user) => ({
+  _id: user._id.toString(),
+  firstName: user.firstName,
+  lastName: user.lastName,
+  email: user.email,
+  username: user.username,
+  role: user.role,
+  isBanned: user.isBanned === true,
+  createdAt: user.createdAt,
+  updatedAt: user.updatedAt,
+  bannedAt: user.bannedAt,
+  bannedByAdminId: user.bannedByAdminId?.toString(),
+  promotedAt: user.promotedAt,
+  promotedByAdminId: user.promotedByAdminId?.toString(),
+});
+
 export const createUser = async (
   firstName,
   lastName,
@@ -56,6 +72,7 @@ export const createUser = async (
       usernameNormalized,
       hashedPassword,
       role,
+      isBanned: false,
       watchlist: [],
       createdAt: now,
       updatedAt: now,
@@ -82,6 +99,10 @@ export const loginUser = async (username, password) => {
     throw "invalid username or password";
   }
 
+  if (user.isBanned === true) {
+    throw "account is banned";
+  }
+
   return {
     _id: user._id.toString(),
     firstName: user.firstName,
@@ -89,6 +110,7 @@ export const loginUser = async (username, password) => {
     username: user.username,
     email: user.email,
     role: user.role,
+    isBanned: false,
   };
 };
 
@@ -120,6 +142,68 @@ export const toggleWatchlist = async (userId, buildingId) => {
   );
 
   return { watching: !inList };
+};
+
+export const getAllUsersForAdmin = async () => {
+  const col = await users();
+  const userList = await col
+    .find({})
+    .sort({ createdAt: -1 })
+    .toArray();
+
+  return userList.map(serializeUserForAdmin);
+};
+
+export const banUser = async (id, adminId) => {
+  id = checkId(id, "userId");
+  adminId = checkId(adminId, "adminId");
+
+  if (id === adminId) {
+    throw "admins cannot ban their own account";
+  }
+
+  const now = new Date();
+  const col = await users();
+  const result = await col.findOneAndUpdate(
+    { _id: new ObjectId(id) },
+    {
+      $set: {
+        isBanned: true,
+        bannedAt: now,
+        bannedByAdminId: new ObjectId(adminId),
+        updatedAt: now,
+      },
+    },
+    { returnDocument: "after" }
+  );
+
+  if (!result) throw "user not found";
+
+  return serializeUserForAdmin(result);
+};
+
+export const promoteUserToAdmin = async (id, adminId) => {
+  id = checkId(id, "userId");
+  adminId = checkId(adminId, "adminId");
+
+  const now = new Date();
+  const col = await users();
+  const result = await col.findOneAndUpdate(
+    { _id: new ObjectId(id) },
+    {
+      $set: {
+        role: "admin",
+        promotedAt: now,
+        promotedByAdminId: new ObjectId(adminId),
+        updatedAt: now,
+      },
+    },
+    { returnDocument: "after" }
+  );
+
+  if (!result) throw "user not found";
+
+  return serializeUserForAdmin(result);
 };
 
 export const getProfile = async (id) => {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,9 +1,36 @@
 import { Router } from 'express';
-import { buildingData } from '../data/index.js';
+import { buildingData, userData } from '../data/index.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
+
+router.get(
+  '/admin/users',
+  requireAdmin,
+  createApiHandler(
+    async () => userData.getAllUsersForAdmin(),
+    { errorStatus: 400 }
+  )
+);
+
+router.patch(
+  '/admin/users/:id/ban',
+  requireAdmin,
+  createApiHandler(
+    async (req) => userData.banUser(req.params.id, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
+
+router.patch(
+  '/admin/users/:id/promote',
+  requireAdmin,
+  createApiHandler(
+    async (req) => userData.promoteUserToAdmin(req.params.id, req.session.user._id),
+    { errorStatus: 400 }
+  )
+);
 
 router.post(
   '/admin/buildings',


### PR DESCRIPTION
## Summary

Implemented back-end issue #38: admin user management endpoints.

## What Changed

- Added admin-only user management API endpoints:
  - `GET /admin/users`
  - `PATCH /admin/users/:id/ban`
  - `PATCH /admin/users/:id/promote`
- Added data-layer helpers for listing users, banning users, and promoting users to admin.
- Added safe admin-facing user serialization so `hashedPassword` is never returned.
- Added `isBanned` to newly created users.
- Blocked banned users from logging in.
- Prevented admins from banning their own account.

## Behavior Impact

Admins can now list users, ban accounts, and promote users to admin role through protected admin endpoints. Banned users receive a clear login error and cannot create new sessions.

## Files Changed

- [data/users.js](/Users/steve/Desktop/CS-546-B-FP/back-end-main/data/users.js:1)
- [routes/admin.js](/Users/steve/Desktop/CS-546-B-FP/back-end-main/routes/admin.js:1)

## Testing

- Passed `node --check data/users.js`.
- Passed `node --check routes/admin.js`.
- Passed `git diff --check`.
- Started backend with `PORT=4324 npm start`.
- Verified admin login with a temporary admin user.
- Verified `GET /admin/users` returns safe user data.
- Verified `PATCH /admin/users/:id/promote`.
- Verified `PATCH /admin/users/:id/ban`.
- Verified banned user login returns `401` with `account is banned`.
- Verified unauthenticated admin endpoint access returns `401`.
- Verified admin self-ban returns `400`.
- Cleaned up temporary MongoDB test users.

## Notes

This PR only covers issue #38. It does not include rate limiting, profile endpoints, bulk import, search filters, moderation, or review aggregation.
