### PR TITLE
feat: add api rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import session from 'express-session';
 import cookieParser from 'cookie-parser';
 import registerRoutes from './routes/index.js';
+import { apiRateLimiter } from './middleware/rate-limit.js';
 
 const app = express();
 const port = Number(process.env.PORT) || 3001;
@@ -16,6 +17,7 @@ app.use(session({
   saveUninitialized: false,
   cookie: { httpOnly: true, maxAge: 1000 * 60 * 60 * 24 }
 }));
+app.use(apiRateLimiter);
 
 registerRoutes(app);
 

--- a/middleware/rate-limit.js
+++ b/middleware/rate-limit.js
@@ -1,0 +1,83 @@
+import { sendApiError } from '../utils/api-response.js';
+
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_ANONYMOUS_LIMIT = 100;
+const DEFAULT_AUTHENTICATED_LIMIT = 300;
+
+const getRequestIdentity = (req) => {
+  const userId = req.session?.user?._id;
+
+  if (userId) {
+    return {
+      key: `user:${userId}`,
+      limitType: 'authenticated'
+    };
+  }
+
+  return {
+    key: `ip:${req.ip || req.socket?.remoteAddress || 'unknown'}`,
+    limitType: 'anonymous'
+  };
+};
+
+const setRateLimitHeaders = (res, { limit, remaining, resetAt }) => {
+  const resetSeconds = Math.ceil(resetAt / 1000);
+
+  res.set('RateLimit-Limit', String(limit));
+  res.set('RateLimit-Remaining', String(remaining));
+  res.set('RateLimit-Reset', String(resetSeconds));
+};
+
+const pruneExpiredBuckets = (store, now) => {
+  for (const [key, bucket] of store.entries()) {
+    if (bucket.resetAt <= now) {
+      store.delete(key);
+    }
+  }
+};
+
+export const createRateLimiter = ({
+  windowMs = DEFAULT_WINDOW_MS,
+  anonymousLimit = DEFAULT_ANONYMOUS_LIMIT,
+  authenticatedLimit = DEFAULT_AUTHENTICATED_LIMIT,
+  now = () => Date.now(),
+  store = new Map()
+} = {}) => {
+  let nextPruneAt = now() + windowMs;
+
+  return (req, res, next) => {
+    const currentTime = now();
+
+    if (currentTime >= nextPruneAt) {
+      pruneExpiredBuckets(store, currentTime);
+      nextPruneAt = currentTime + windowMs;
+    }
+
+    const { key, limitType } = getRequestIdentity(req);
+    const limit = limitType === 'authenticated' ? authenticatedLimit : anonymousLimit;
+    const existingBucket = store.get(key);
+    const bucket = !existingBucket || existingBucket.resetAt <= currentTime
+      ? { count: 0, resetAt: currentTime + windowMs }
+      : existingBucket;
+
+    bucket.count += 1;
+    store.set(key, bucket);
+
+    const remaining = Math.max(limit - bucket.count, 0);
+    setRateLimitHeaders(res, {
+      limit,
+      remaining,
+      resetAt: bucket.resetAt
+    });
+
+    if (bucket.count > limit) {
+      const retryAfterSeconds = Math.max(Math.ceil((bucket.resetAt - currentTime) / 1000), 1);
+      res.set('Retry-After', String(retryAfterSeconds));
+      return sendApiError(res, 'too many requests', { status: 429 });
+    }
+
+    return next();
+  };
+};
+
+export const apiRateLimiter = createRateLimiter();


### PR DESCRIPTION
## Summary

Implemented back-end issue #41: API rate limiting middleware.

## What Changed

- Added a reusable in-memory rate limiting middleware.
- Applied rate limiting globally before API routes.
- Added separate limits for request identity types:
  - anonymous users: 100 requests per 15 minutes
  - authenticated users: 300 requests per 15 minutes
- Identifies authenticated users by `req.session.user._id`.
- Identifies anonymous users by request IP.
- Adds rate limit response headers:
  - `RateLimit-Limit`
  - `RateLimit-Remaining`
  - `RateLimit-Reset`
  - `Retry-After` when limited
- Returns a consistent API error response with `429` and `too many requests`.

## Behavior Impact

API endpoints now have basic abuse protection. Authenticated users get a higher request allowance than anonymous visitors, while excessive requests receive a clear `429` response.

## Files Changed

- [middleware/rate-limit.js](/Users/steve/Desktop/CS-546-B-FP/back-end-main/middleware/rate-limit.js:1)
- [app.js](/Users/steve/Desktop/CS-546-B-FP/back-end-main/app.js:1)

## Testing

- Passed `node --check middleware/rate-limit.js`.
- Passed `node --check app.js`.
- Passed `git diff --check`.
- Ran a direct middleware behavior test covering:
  - anonymous request bucket
  - authenticated request bucket
  - different limits per identity type
  - `429` response behavior
  - reset after window expiry
- Started backend with `PORT=4325 npm start`.
- Verified the 101st anonymous HTTP request returned `429`.
- Verified HTTP response included `RateLimit-Limit: 100`, `RateLimit-Remaining: 0`, and `Retry-After`.

## Notes

This PR only covers issue #41. It does not include admin user management, profile endpoints, bulk import, advanced search filters, review moderation, or review aggregation.
