### PR TITLE
feat: add user profile management endpoints

### DIFF
--- a/data/users.js
+++ b/data/users.js
@@ -1,6 +1,7 @@
 import { ObjectId } from 'mongodb';
 import bcrypt from 'bcryptjs';
 import { users } from '../config/mongoCollections.js';
+import { buildings } from '../config/mongoCollections.js';
 import { reviews } from '../config/mongoCollections.js';
 import { shortlists } from '../config/mongoCollections.js';
 import {
@@ -22,6 +23,18 @@ const normalizeLoginCredential = (value) =>
         field: "usernameNormalized",
         value: checkUsername(value, "username"),
       };
+
+const serializeProfile = (user) => ({
+  _id: user._id.toString(),
+  firstName: user.firstName,
+  lastName: user.lastName,
+  username: user.username,
+  email: user.email,
+  role: user.role,
+  watchlist: (user.watchlist || []).map((id) => id.toString()),
+  createdAt: user.createdAt,
+  updatedAt: user.updatedAt
+});
 
 export const createUser = async (
   firstName,
@@ -127,10 +140,7 @@ export const getProfile = async (id) => {
   const col = await users();
   const user = await col.findOne({ _id: new ObjectId(id) });
   if (!user) throw 'user not found';
-  const { hashedPassword, ...profile } = user;
-  profile._id = profile._id.toString();
-  profile.watchlist = (profile.watchlist || []).map(wid => wid.toString());
-  return profile;
+  return serializeProfile(user);
 };
 
 export const updateProfile = async (id, { firstName, lastName, email, username }) => {
@@ -139,20 +149,32 @@ export const updateProfile = async (id, { firstName, lastName, email, username }
   lastName = checkString(lastName, 'lastName');
   email = checkEmail(email);
   username = checkUsername(username, 'username');
+  const emailNormalized = email.toLowerCase();
+  const usernameNormalized = username.toLowerCase();
 
   const col = await users();
   const existing = await col.findOne({
     _id: { $ne: new ObjectId(id) },
     $or: [
-      { email: buildCaseInsensitiveExactMatch(email) },
-      { username: buildCaseInsensitiveExactMatch(username) }
+      { emailNormalized },
+      { usernameNormalized }
     ]
   });
   if (existing) throw 'email or username already taken';
 
   const result = await col.findOneAndUpdate(
     { _id: new ObjectId(id) },
-    { $set: { firstName, lastName, email, username, updatedAt: new Date() } },
+    {
+      $set: {
+        firstName,
+        lastName,
+        email,
+        emailNormalized,
+        username,
+        usernameNormalized,
+        updatedAt: new Date()
+      }
+    },
     { returnDocument: 'after' }
   );
   if (!result) throw 'user not found';
@@ -165,6 +187,28 @@ export const updateProfile = async (id, { firstName, lastName, email, username }
     email: result.email,
     role: result.role
   };
+};
+
+export const getUserWatchlist = async (id) => {
+  id = checkId(id);
+  const col = await users();
+  const user = await col.findOne({ _id: new ObjectId(id) });
+  if (!user) throw 'user not found';
+
+  const watchlistIds = user.watchlist || [];
+  if (watchlistIds.length === 0) return [];
+
+  const buildingCol = await buildings();
+  const watchlistBuildings = await buildingCol
+    .find({ _id: { $in: watchlistIds } })
+    .toArray();
+  const buildingsById = new Map(
+    watchlistBuildings.map((building) => [building._id.toString(), building])
+  );
+
+  return watchlistIds
+    .map((buildingId) => buildingsById.get(buildingId.toString()))
+    .filter(Boolean);
 };
 
 export const changePassword = async (id, currentPassword, newPassword) => {

--- a/data/users.js
+++ b/data/users.js
@@ -1,9 +1,6 @@
 import { ObjectId } from 'mongodb';
 import bcrypt from 'bcryptjs';
-import { users } from '../config/mongoCollections.js';
-import { buildings } from '../config/mongoCollections.js';
-import { reviews } from '../config/mongoCollections.js';
-import { shortlists } from '../config/mongoCollections.js';
+import { users, buildings, reviews, shortlists } from '../config/mongoCollections.js';
 import {
   checkString,
   checkId,
@@ -34,6 +31,17 @@ const serializeProfile = (user) => ({
   watchlist: (user.watchlist || []).map((id) => id.toString()),
   createdAt: user.createdAt,
   updatedAt: user.updatedAt
+});
+
+const serializeBuilding = (building) => ({
+  _id: building._id.toString(),
+  streetAddress: building.streetAddress,
+  borough: building.borough,
+  ownerName: building.ownerName,
+  housingRecords: building.housingRecords,
+  riskSummary: building.riskSummary,
+  createdAt: building.createdAt,
+  updatedAt: building.updatedAt
 });
 
 export const createUser = async (
@@ -179,14 +187,7 @@ export const updateProfile = async (id, { firstName, lastName, email, username }
   );
   if (!result) throw 'user not found';
 
-  return {
-    _id: result._id.toString(),
-    firstName: result.firstName,
-    lastName: result.lastName,
-    username: result.username,
-    email: result.email,
-    role: result.role
-  };
+  return serializeProfile(result);
 };
 
 export const getUserWatchlist = async (id) => {
@@ -201,6 +202,7 @@ export const getUserWatchlist = async (id) => {
   const buildingCol = await buildings();
   const watchlistBuildings = await buildingCol
     .find({ _id: { $in: watchlistIds } })
+    .limit(100)
     .toArray();
   const buildingsById = new Map(
     watchlistBuildings.map((building) => [building._id.toString(), building])
@@ -208,7 +210,8 @@ export const getUserWatchlist = async (id) => {
 
   return watchlistIds
     .map((buildingId) => buildingsById.get(buildingId.toString()))
-    .filter(Boolean);
+    .filter(Boolean)
+    .map(serializeBuilding);
 };
 
 export const changePassword = async (id, currentPassword, newPassword) => {

--- a/routes/users.js
+++ b/routes/users.js
@@ -5,12 +5,18 @@ import { createApiHandler, sendApiSuccess } from '../utils/api-response.js';
 
 const router = Router();
 
+const getUserErrorStatus = (error) => {
+  if (error === 'user not found') return 404;
+  if (error === 'forbidden') return 403;
+  return 400;
+};
+
 router.get(
   '/users/me',
   requireAuth,
   createApiHandler(
     async (req) => userData.getProfile(req.session.user._id),
-    { errorStatus: 400 }
+    { getErrorStatus: getUserErrorStatus }
   )
 );
 
@@ -26,7 +32,22 @@ router.put(
       req.session.user = updated;
       return updated;
     },
-    { errorStatus: 400 }
+    { getErrorStatus: getUserErrorStatus }
+  )
+);
+
+router.get(
+  '/users/:id/watchlist',
+  requireAuth,
+  createApiHandler(
+    async (req) => {
+      if (req.params.id !== req.session.user._id && req.session.user.role !== 'admin') {
+        throw 'forbidden';
+      }
+
+      return userData.getUserWatchlist(req.params.id);
+    },
+    { getErrorStatus: getUserErrorStatus }
   )
 );
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -41,11 +41,14 @@ router.get(
   requireAuth,
   createApiHandler(
     async (req) => {
-      if (req.params.id !== req.session.user._id && req.session.user.role !== 'admin') {
+      const targetId = req.params.id.trim();
+      const currentUserId = String(req.session.user._id);
+
+      if (targetId !== currentUserId && req.session.user.role !== 'admin') {
         throw 'forbidden';
       }
 
-      return userData.getUserWatchlist(req.params.id);
+      return userData.getUserWatchlist(targetId);
     },
     { getErrorStatus: getUserErrorStatus }
   )


### PR DESCRIPTION
## Summary

Implemented back-end issue #29: user profile management endpoints.

## What Changed

- Completed user profile endpoint behavior for:
  - `GET /users/me`
  - `PUT /users/me`
  - `GET /users/:id/watchlist`
- Fixed profile update duplicate checks to use normalized email and username fields.
- Ensured profile updates persist `emailNormalized` and `usernameNormalized`.
- Added safe profile serialization so profile responses do not expose password hashes or normalized identity fields.
- Added user watchlist lookup that returns the watched building records in the user's watchlist order.
- Protected `GET /users/:id/watchlist` so regular users can only view their own watchlist, while admins can view any user's watchlist.

## Behavior Impact

Users can now retrieve and update their own profile safely, and clients can fetch a user's watchlist through a dedicated endpoint. Profile updates keep case-insensitive email and username behavior consistent with registration and login.

## Files Changed

- `data/users.js`
- `routes/users.js`

## Testing

- Passed `node --check data/users.js`.
- Passed `node --check routes/users.js`.
- Passed `git diff --check`.
- Ran a data-layer behavior test covering:
  - safe profile serialization
  - profile update normalization
  - duplicate email rejection
  - normalized field persistence
  - watchlist building lookup
- Started backend with `PORT=4326 npm start`.
- Verified temporary user login.
- Verified `GET /users/me`.
- Verified `PUT /users/me` updates and normalizes profile data.
- Verified `GET /users/:id/watchlist` returns the user's watched building records.
- Verified regular users receive `403` when requesting another user's watchlist.
- Cleaned up temporary MongoDB test users and building.

## Notes

This PR only covers issue #29. It does not include admin user management, rate limiting, bulk import, advanced search filters, review moderation, or review aggregation.
