### PR TITLE
feat: add admin bulk building import

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import { apiRateLimiter } from './middleware/rate-limit.js';
 const app = express();
 const port = Number(process.env.PORT) || 3001;
 
+app.use(express.text({ type: ['text/csv', 'application/csv'] }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());

--- a/data/buildings.js
+++ b/data/buildings.js
@@ -38,6 +38,10 @@ const buildBuildingSort = (sortBy, sortOrder) => {
   return { createdAt: direction, _id: 1 };
 };
 
+const normalizeDuplicatePart = (value) => String(value || '').trim().toLowerCase();
+const normalizeDuplicateKey = ({ streetAddress, borough }) =>
+  `${normalizeDuplicatePart(streetAddress)}|${normalizeDuplicatePart(borough)}`;
+
 const normalizeBuildingInput = (data, { requireCoreFields = false } = {}) => {
   if (!data || typeof data !== 'object' || Array.isArray(data)) {
     throw 'data must be an object';
@@ -63,6 +67,60 @@ const normalizeBuildingInput = (data, { requireCoreFields = false } = {}) => {
   }
 
   return normalized;
+};
+
+const buildBuildingDocument = (data, normalized, adminId, now) => {
+  const {
+    _id,
+    createdByAdminId,
+    updatedByAdminId,
+    createdAt,
+    updatedAt,
+    ...safeData
+  } = data;
+
+  return {
+    ...safeData,
+    ...normalized,
+    riskSummary: data.riskSummary ?? { highlights: [], lastCalculatedAt: now },
+    housingRecords: data.housingRecords ?? [],
+    reviewCount: 0,
+    averageRating: 0,
+    issueTagFrequency: {},
+    createdByAdminId: new ObjectId(adminId),
+    updatedByAdminId: new ObjectId(adminId),
+    createdAt: now,
+    updatedAt: now
+  };
+};
+
+const normalizeBulkBuildingInput = (buildingList) => {
+  if (!Array.isArray(buildingList)) {
+    throw 'buildings must be an array';
+  }
+
+  if (buildingList.length === 0) {
+    throw 'buildings must contain at least one building';
+  }
+
+  const seen = new Set();
+
+  return buildingList.map((building, index) => {
+    const normalized = normalizeBuildingInput(building, { requireCoreFields: true });
+    const duplicateKey = normalizeDuplicateKey(normalized);
+
+    if (seen.has(duplicateKey)) {
+      throw `duplicate building in import at index ${index}: ${normalized.streetAddress}, ${normalized.borough}`;
+    }
+
+    seen.add(duplicateKey);
+
+    return {
+      original: building,
+      normalized,
+      duplicateKey
+    };
+  });
 };
 
 export const getAllBuildings = async ({
@@ -135,21 +193,39 @@ export const createBuilding = async (data, adminId) => {
   const normalized = normalizeBuildingInput(data, { requireCoreFields: true });
   const now = new Date();
   const col = await buildings();
-  const doc = {
-    ...data,
-    ...normalized,
-    riskSummary: data.riskSummary ?? { highlights: [], lastCalculatedAt: now },
-    housingRecords: data.housingRecords ?? [],
-    reviewCount: 0,
-    averageRating: 0,
-    issueTagFrequency: {},
-    createdByAdminId: new ObjectId(adminId),
-    updatedByAdminId: new ObjectId(adminId),
-    createdAt: now,
-    updatedAt: now
-  };
+  const doc = buildBuildingDocument(data, normalized, adminId, now);
   const { insertedId } = await col.insertOne(doc);
   return { _id: insertedId.toString() };
+};
+
+export const importBuildings = async (buildingList, adminId) => {
+  adminId = checkId(adminId, 'adminId');
+  const normalizedBuildings = normalizeBulkBuildingInput(buildingList);
+  const col = await buildings();
+  const boroughs = [...new Set(normalizedBuildings.map(({ normalized }) => normalized.borough))];
+  const existingBuildings = await col
+    .find(
+      { borough: { $in: boroughs } },
+      { projection: { streetAddress: 1, borough: 1 } }
+    )
+    .toArray();
+  const existingKeys = new Set(existingBuildings.map(normalizeDuplicateKey));
+  const duplicate = normalizedBuildings.find(({ duplicateKey }) => existingKeys.has(duplicateKey));
+
+  if (duplicate) {
+    throw `building already exists: ${duplicate.normalized.streetAddress}, ${duplicate.normalized.borough}`;
+  }
+
+  const now = new Date();
+  const docs = normalizedBuildings.map(({ original, normalized }) =>
+    buildBuildingDocument(original, normalized, adminId, now)
+  );
+  const result = await col.insertMany(docs, { ordered: true });
+
+  return {
+    insertedCount: result.insertedCount,
+    insertedIds: Object.values(result.insertedIds).map((id) => id.toString())
+  };
 };
 
 export const updateBuilding = async (id, data, adminId) => {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2,11 +2,36 @@ import { Router } from 'express';
 import { buildingData, reviewData, userData } from '../data/index.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { createApiHandler } from '../utils/api-response.js';
+import { parseCsvObjects } from '../utils/csv.js';
 
 const router = Router();
 
 const getReviewModerationErrorStatus = (error) =>
   error === 'review not found' ? 404 : 400;
+
+const getBuildingImportPayload = (body) => {
+  if (Array.isArray(body)) {
+    return body;
+  }
+
+  if (typeof body === 'string') {
+    return parseCsvObjects(body);
+  }
+
+  if (!body || typeof body !== 'object') {
+    throw 'building import payload must be a JSON array, a buildings array, or CSV text';
+  }
+
+  if (Array.isArray(body.buildings)) {
+    return body.buildings;
+  }
+
+  if (typeof body.csv === 'string') {
+    return parseCsvObjects(body.csv);
+  }
+
+  throw 'building import payload must be a JSON array, a buildings array, or CSV text';
+};
 
 router.get(
   '/admin/users',
@@ -40,6 +65,18 @@ router.post(
   requireAdmin,
   createApiHandler(
     async (req) => buildingData.createBuilding(req.body, req.session.user._id),
+    { successStatus: 201, errorStatus: 400 }
+  )
+);
+
+router.post(
+  '/admin/buildings/import',
+  requireAdmin,
+  createApiHandler(
+    async (req) => buildingData.importBuildings(
+      getBuildingImportPayload(req.body),
+      req.session.user._id
+    ),
     { successStatus: 201, errorStatus: 400 }
   )
 );

--- a/utils/csv.js
+++ b/utils/csv.js
@@ -1,0 +1,90 @@
+const parseCsvRows = (csvText) => {
+  if (typeof csvText !== 'string') {
+    throw 'csv import data must be a string';
+  }
+
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < csvText.length; i += 1) {
+    const char = csvText[i];
+    const nextChar = csvText[i + 1];
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        field += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      row.push(field);
+      field = '';
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && nextChar === '\n') {
+        i += 1;
+      }
+
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      continue;
+    }
+
+    field += char;
+  }
+
+  if (inQuotes) {
+    throw 'csv import data has an unterminated quoted field';
+  }
+
+  row.push(field);
+  rows.push(row);
+
+  return rows.filter((items) => items.some((item) => item.trim().length > 0));
+};
+
+export const parseCsvObjects = (csvText) => {
+  const rows = parseCsvRows(csvText);
+
+  if (rows.length < 2) {
+    throw 'csv import data must include a header row and at least one building row';
+  }
+
+  const headers = rows[0].map((header) => header.trim());
+
+  if (headers.some((header) => header.length === 0)) {
+    throw 'csv import headers must not be empty';
+  }
+
+  if (new Set(headers).size !== headers.length) {
+    throw 'csv import headers must be unique';
+  }
+
+  return rows.slice(1).map((row, rowIndex) => {
+    if (row.length !== headers.length) {
+      throw `csv row ${rowIndex + 2} must contain ${headers.length} value${headers.length === 1 ? '' : 's'}`;
+    }
+
+    const building = {};
+
+    headers.forEach((header, index) => {
+      const value = row[index].trim();
+
+      if (value.length > 0) {
+        building[header] = value;
+      }
+    });
+
+    return building;
+  });
+};


### PR DESCRIPTION
## Summary

Implemented back-end issue #42: admin bulk building import endpoint.

## What Changed

- Added admin-only bulk import endpoint:
  - `POST /admin/buildings/import`
- Added support for JSON import payloads:
  - raw JSON array
  - `{ "buildings": [...] }`
- Added support for CSV import payloads:
  - `Content-Type: text/csv`
  - `{ "csv": "..." }`
- Added a small CSV parser for header-based CSV building rows.
- Added bulk building validation using the existing building input rules.
- Added duplicate detection for:
  - duplicate buildings inside the same import payload
  - buildings that already exist in the database by `streetAddress + borough`
- Added `text/csv` request parsing in the app.
- Reused the building document creation path for single and bulk create.

## Behavior Impact

Admins can import multiple buildings in one request from JSON or CSV input. Invalid rows and duplicate buildings are rejected with clear `400` errors before insertion.

## Files Changed

- `app.js`
- `data/buildings.js`
- `routes/admin.js`
- `utils/csv.js`

## Testing

- Passed `node --check utils/csv.js`.
- Passed `node --check data/buildings.js`.
- Passed `node --check routes/admin.js`.
- Passed `node --check app.js`.
- Passed `git diff --check`.
- Ran CSV parser behavior tests covering:
  - quoted CSV fields
  - comma inside quoted fields
  - blank optional CSV values
  - malformed row rejection
  - duplicate header rejection
- Ran data-layer behavior tests covering:
  - valid JSON bulk import
  - duplicate building inside import payload
  - duplicate building already existing in database
- Started backend with `PORT=4327 npm start`.
- Verified admin login with a temporary admin user.
- Verified JSON import returns `201`.
- Verified `text/csv` import returns `201`.
- Verified duplicate import returns `400`.
- Verified unauthenticated import returns `401`.
- Cleaned up temporary MongoDB test user and buildings.

## Notes

This PR only covers issue #42. It does not include advanced search filters, review moderation, or review aggregation.
