### PR TITLE
feat: add admin review moderation endpoints

### DIFF
--- a/data/reviews.js
+++ b/data/reviews.js
@@ -144,6 +144,10 @@ const moderateReviewByAdmin = async (id, adminId, moderationStatus) => {
 
   if (!result) throw 'review not found';
 
+  if (status) {
+    await refreshBuildingReviewAggregation(result.buildingId.toString());
+  }
+
   return result;
 };
 

--- a/data/reviews.js
+++ b/data/reviews.js
@@ -5,12 +5,19 @@ import {
   VALIDATION_LIMITS,
   checkBoundedText,
   checkId,
+  checkEnum,
   checkInt,
   checkIssueTags
 } from './validation.js';
 
 export const DUPLICATE_REVIEW_ERROR =
   'review already exists for this building; please edit your existing review instead';
+export const REVIEW_MODERATION_STATUS_VALUES = Object.freeze(['flagged', 'hidden', 'deleted']);
+
+const REVIEW_STATUS_BY_MODERATION_STATUS = Object.freeze({
+  hidden: 'hidden',
+  deleted: 'deleted'
+});
 
 const getIssueTagFrequency = (reviewList) => {
   const frequency = {};
@@ -105,6 +112,49 @@ export const createReview = async (buildingId, userId, reviewText, rating, issue
 
   return { _id: insertedId.toString() };
 };
+
+const moderateReviewByAdmin = async (id, adminId, moderationStatus) => {
+  id = checkId(id);
+  adminId = checkId(adminId, 'adminId');
+  moderationStatus = checkEnum(
+    moderationStatus,
+    REVIEW_MODERATION_STATUS_VALUES,
+    'moderationStatus'
+  );
+
+  const now = new Date();
+  const update = {
+    moderationStatus,
+    moderatedByAdminId: new ObjectId(adminId),
+    moderatedAt: now,
+    updatedAt: now
+  };
+  const status = REVIEW_STATUS_BY_MODERATION_STATUS[moderationStatus];
+
+  if (status) {
+    update.status = status;
+  }
+
+  const col = await reviews();
+  const result = await col.findOneAndUpdate(
+    { _id: new ObjectId(id) },
+    { $set: update },
+    { returnDocument: 'after' }
+  );
+
+  if (!result) throw 'review not found';
+
+  return result;
+};
+
+export const flagReviewByAdmin = async (id, adminId) =>
+  moderateReviewByAdmin(id, adminId, 'flagged');
+
+export const hideReviewByAdmin = async (id, adminId) =>
+  moderateReviewByAdmin(id, adminId, 'hidden');
+
+export const deleteReviewByAdmin = async (id, adminId) =>
+  moderateReviewByAdmin(id, adminId, 'deleted');
 
 export const updateReview = async (id, userId, reviewText, rating, issueTags) => {
   id = checkId(id);

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,9 +1,12 @@
 import { Router } from 'express';
-import { buildingData, userData } from '../data/index.js';
+import { buildingData, reviewData, userData } from '../data/index.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { createApiHandler } from '../utils/api-response.js';
 
 const router = Router();
+
+const getReviewModerationErrorStatus = (error) =>
+  error === 'review not found' ? 404 : 400;
 
 router.get(
   '/admin/users',
@@ -56,6 +59,33 @@ router.delete(
   createApiHandler(
     async (req) => buildingData.deleteBuilding(req.params.id),
     { errorStatus: 400 }
+  )
+);
+
+router.patch(
+  '/admin/reviews/:id/flag',
+  requireAdmin,
+  createApiHandler(
+    async (req) => reviewData.flagReviewByAdmin(req.params.id, req.session.user._id),
+    { getErrorStatus: getReviewModerationErrorStatus }
+  )
+);
+
+router.patch(
+  '/admin/reviews/:id/hide',
+  requireAdmin,
+  createApiHandler(
+    async (req) => reviewData.hideReviewByAdmin(req.params.id, req.session.user._id),
+    { getErrorStatus: getReviewModerationErrorStatus }
+  )
+);
+
+router.delete(
+  '/admin/reviews/:id',
+  requireAdmin,
+  createApiHandler(
+    async (req) => reviewData.deleteReviewByAdmin(req.params.id, req.session.user._id),
+    { getErrorStatus: getReviewModerationErrorStatus }
   )
 );
 


### PR DESCRIPTION
## Summary

Implemented back-end issue #39: admin review moderation endpoints.

## What Changed

- Added admin-only review moderation endpoints:
  - `PATCH /admin/reviews/:id/flag`
  - `PATCH /admin/reviews/:id/hide`
  - `DELETE /admin/reviews/:id`
- Added review moderation data-layer helpers for:
  - flagging any review
  - hiding any review
  - deleting any review
- Added moderation status tracking fields:
  - `moderationStatus`
  - `moderatedByAdminId`
  - `moderatedAt`
- Kept flagged reviews publicly visible.
- Hid reviews by setting `status` to `hidden`.
- Deleted reviews by setting `status` to `deleted`.
- Added `404` handling when an admin tries to moderate a review that does not exist.

## Behavior Impact

Admins can now moderate any review through protected admin endpoints. Flagged reviews remain visible but are tracked for moderation, while hidden and deleted reviews are removed from public building review results.

## Files Changed

- `data/reviews.js`
- `routes/admin.js`

## Testing

- Passed `node --check data/reviews.js`.
- Passed `node --check routes/admin.js`.
- Passed `git diff --check`.
- Ran data-layer behavior tests covering:
  - admin flag review
  - admin hide review
  - admin delete review
  - moderation status tracking
  - moderated admin ID tracking
  - hidden reviews excluded from public building reviews
  - missing review rejection
- Started backend with `PORT=4330 npm start`.
- Verified unauthenticated moderation returns `401`.
- Verified non-admin moderation returns `403`.
- Verified admin flag returns `200`.
- Verified flagged reviews remain visible in `GET /buildings/:id/reviews`.
- Verified admin hide returns `200`.
- Verified hidden reviews are excluded from `GET /buildings/:id/reviews`.
- Verified admin delete returns `200`.
- Verified missing review moderation returns `404`.
- Cleaned up temporary MongoDB test users, building, and reviews.

## Notes

This PR only covers issue #39. It does not include advanced building search filters, review aggregation, or bulk building import work.
