### PR TITLE
Fix review index creation conflict

### DIFF
--- a/tasks/createIndexes.js
+++ b/tasks/createIndexes.js
@@ -50,7 +50,7 @@ const createIndexes = async () => {
   );
 
   await reviewCollection.createIndex(
-    { buildingId: 1, userId: 1 },
+    { buildingId: 1, userId: 1, status: 1 },
     {
       unique: true,
       partialFilterExpression: { status: "published" },


### PR DESCRIPTION
Fixed MongoDB index creation conflict by aligning the review unique index definition with the existing index.

Tested:
- npm run indexes